### PR TITLE
correct capitals in handShift

### DIFF
--- a/__tests__/functional.test.js
+++ b/__tests__/functional.test.js
@@ -1239,7 +1239,7 @@ test('a handShift note', async () => {
   const htmlData = await page.evaluate(`getData()`);
   expect(htmlData).toBe('a note<span class=\"note\" wce_orig=\"\" wce=\"__t=note&amp;__n=&amp;help=Help&amp;note_type=changeOfHand&amp;note_type_other=&amp;newHand=&amp;note_text=\"><span class=\"format_start mceNonEditable\">‹</span>Note<span class=\"format_end mceNonEditable\">›</span></span>');
   const xmlData = await page.evaluate(`getTEI()`);
-  expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="editorial" xml:id="BKV--2"><handshift/></note>' + xmlTail);
+  expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="editorial" xml:id="BKV--2"><handShift/></note>' + xmlTail);
 }, 200000);
 
 test('a handShift note with new hand', async () => {
@@ -1260,7 +1260,7 @@ test('a handShift note with new hand', async () => {
   const htmlData = await page.evaluate(`getData()`);
   expect(htmlData).toBe('a note<span class=\"note\" wce_orig=\"\" wce=\"__t=note&amp;__n=&amp;help=Help&amp;note_type=changeOfHand&amp;note_type_other=&amp;newHand=new%20hand&amp;note_text=\"><span class=\"format_start mceNonEditable\">‹</span>Note<span class=\"format_end mceNonEditable\">›</span></span>');
   const xmlData = await page.evaluate(`getTEI()`);
-  expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="editorial" xml:id="BKV--2"><handshift scribe="new hand"/></note>' + xmlTail);
+  expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="editorial" xml:id="BKV--2"><handShift scribe="new hand"/></note>' + xmlTail);
 }, 200000);
 
 test('1 line of commentary text note', async () => {

--- a/__tests__/wce_tei.dom.test.js
+++ b/__tests__/wce_tei.dom.test.js
@@ -479,7 +479,7 @@ const notes = new Map([
   ],
   // a handshift note - needs to be changed to handShift [issue #12]
   [ 'a handShift note',
-    [ '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handshift/></note>',
+    [ '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handShift/></note>',
       'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
       'note_type_other=&amp;newHand="><span class="format_start mceNonEditable">‹</span>Note' +
       '<span class="format_end mceNonEditable">›</span></span>'
@@ -487,7 +487,7 @@ const notes = new Map([
   ],
   // spaces added in attribute should be replaced with _ [issue #13]
   [ 'a handShift note with new hand',
-    [ '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handshift scribe="new hand"/></note>',
+    [ '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handShift scribe="new hand"/></note>',
       'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
       'note_type_other=&amp;newHand=new%20hand"><span class="format_start mceNonEditable">‹</span>Note' +
       '<span class="format_end mceNonEditable">›</span></span>'
@@ -947,9 +947,27 @@ const teiToHtmlAndBackWithChange = new Map([
         'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
         'note_type_other=&amp;newHand=new%20hand"><span class="format_start mceNonEditable">‹</span>Note' +
         '<span class="format_end mceNonEditable">›</span></span>',
-        '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handshift scribe="new hand"/></note>'
+        '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handShift scribe="new hand"/></note>'
       ]
     ],
+		// legacy support
+	  [ 'a handShift note',
+	    [ '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handshift/></note>',
+	      'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
+	      'note_type_other=&amp;newHand="><span class="format_start mceNonEditable">‹</span>Note' +
+	      '<span class="format_end mceNonEditable">›</span></span>',
+				'<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handShift/></note>'
+	    ]
+	  ],
+	  // spaces added in attribute should be replaced with _ [issue #13]
+	  [ 'a handShift note with new hand',
+	    [ '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handshift scribe="new hand"/></note>',
+	      'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
+	      'note_type_other=&amp;newHand=new%20hand"><span class="format_start mceNonEditable">‹</span>Note' +
+	      '<span class="format_end mceNonEditable">›</span></span>',
+				'<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handShift scribe="new hand"/></note>',
+	    ]
+	  ],
     [ 'hi rend ol as legacy support for overline',
       [ '<w>test</w><w><hi rend="ol">for</hi></w><w>rendering</w>',
         'test <span class="formatting_overline" wce="__t=formatting_overline" wce_orig="for">' +

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -1522,7 +1522,7 @@ function getHtmlByTei(inputString) {
 			$newNode.setAttribute('class', 'note');
 
 			var wceAttr = '__t=note&__n=&note_text=' + encodeURIComponent(getDomNodeText($teiNode)) + '';
-			if ($teiNode.firstChild && $teiNode.firstChild.nodeName === 'handshift') {// child node <handshift/> => note_type=changeOfHand
+			if ($teiNode.firstChild && ($teiNode.firstChild.nodeName === 'handshift' || $teiNode.firstChild.nodeName === 'handShift')) {// child node <handshift/> => note_type=changeOfHand
 				wceAttr += '&note_type=changeOfHand&note_type_other=';
 				if ($teiNode.firstChild.getAttribute('scribe')) //scribe is optional
 					wceAttr += '&newHand=' + encodeURIComponent($teiNode.firstChild.getAttribute('scribe'));
@@ -3759,9 +3759,9 @@ function getTeiByHtml(inputString, args) {
 		$note.setAttribute('xml:id', xml_id + temp);
 		idSet.add(xml_id + temp);
 
-		// add <handshift/> if necessary
+		// add <handShift/> if necessary
 		if (note_type_value === "changeOfHand") {
-			var $secNewNode = $newDoc.createElement('handshift');
+			var $secNewNode = $newDoc.createElement('handShift');
 			if (arr['newHand'].trim() != '')
 				$secNewNode.setAttribute('scribe', decodeURIComponent(arr['newHand']));
 			$note.appendChild($secNewNode);


### PR DESCRIPTION
This corrects handshift to handShift to comply with TEI guidelines. Legacy support for ingest of handshift is included.

fixes #12 