### PR TITLE
stop using an entity for semicolon in the P menu

### DIFF
--- a/__tests__/functional.test.js
+++ b/__tests__/functional.test.js
@@ -190,7 +190,6 @@ test('test pc typed', async () => {
   expect(xmlData).toBe(xmlHead + '<w>my</w><w>words</w><pc>.</pc>' + xmlTail);
 }, 200000);
 
-// check what semicolon on the punctuation menu is doing cause its weird when used in a test [issue #17]
 // pc with menu
 test('test pc with menu', async () => {
   await frame.type('body#tinymce', 'my words');
@@ -215,6 +214,33 @@ test('test pc with menu', async () => {
                         '<span class=\"format_end mceNonEditable\">›</span></span>');
   const xmlData = await page.evaluate(`getTEI()`);
   expect(xmlData).toBe(xmlHead + '<w>my</w><w>words</w><pc>?</pc>' + xmlTail);
+}, 200000);
+
+// pc with menu
+test('test pc with menu (semicolon as I changed the code for that)', async () => {
+  await frame.type('body#tinymce', 'my words');
+  // open P menu
+  await page.click('button#mceu_17-open');
+  // navigate to question mark on submenu
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowRight');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+	await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+
+  const htmlData = await page.evaluate(`getData()`);
+  expect(htmlData).toBe('my words<span class=\"pc\" wce_orig=\"\" wce=\"__t=pc\">' +
+                        '<span class=\"format_start mceNonEditable\">‹</span>;' +
+                        '<span class=\"format_end mceNonEditable\">›</span></span>');
+  const xmlData = await page.evaluate(`getTEI()`);
+  expect(xmlData).toBe(xmlHead + '<w>my</w><w>words</w><pc>;</pc>' + xmlTail);
 }, 200000);
 
 // abbr

--- a/__tests__/wce_tei.dom.test.js
+++ b/__tests__/wce_tei.dom.test.js
@@ -72,6 +72,12 @@ const basicAnnotation = new Map([
       '<span class="format_end mceNonEditable">›</span></span> ' //space at end is important
  		],
 	],
+	[ 'a semicolon simple <pc> tag',
+	  [ '<pc>;</pc>',
+	 		'<span class="pc" wce="__t=pc"><span class="format_start mceNonEditable">‹</span>;' +
+      '<span class="format_end mceNonEditable">›</span></span> ' //space at end is important
+ 		],
+	],
 	// abbr
 	[ 'nomen sacrum abbreviation with overline',
 		[ '<w>a</w><w><abbr type="nomSac"><hi rend="overline">ns</hi></abbr></w><w>abbreviation</w>',

--- a/wce-ote/plugin/plugin.js
+++ b/wce-ote/plugin/plugin.js
@@ -3609,7 +3609,7 @@
 					},
 					{ text : '; (semicolon)',
 						onclick : function() {
-							ed.execCommand('mceAdd_pc', '&semicolon;');
+							ed.execCommand('mceAdd_pc', ';');
 						}
 					},
 					{ text : '\u203B	(cross with dots)',
@@ -4151,4 +4151,3 @@
 	tinymce.PluginManager.add('wce', tinymce.plugins.wceplugin);
 
 })();
-


### PR DESCRIPTION
For some (unknown) reason the semicolon option on the punctuation menu was adding an entity which wasn't even being added correctly. This changes it to a normal semicolon and adds the relevant tests. 

fixes #17 