### PR TITLE
fix for upload of ex tags without a w wrapper

### DIFF
--- a/__tests__/wce_tei.dom.test.js
+++ b/__tests__/wce_tei.dom.test.js
@@ -964,13 +964,22 @@ const teiToHtmlAndBackWithChange = new Map([
         '<div type="book" n="B04"><w>The</w><w>content</w><w>of</w><w>my</w><w>chapter</w></div>'
    		],
   	],
+		// next two tests test fix for issue #16
 		[ 'whole word <ex> tag (no w wrapper and only one word in total)',
 		  [ '<ex rend="÷">word</ex>',
 				'<span class="part_abbr" wce="__t=part_abbr&amp;__n=&amp;exp_rend_other=&amp;exp_rend=%C3%B7">' +
 	      '<span class="format_start mceNonEditable">‹</span>(word)<span class="format_end mceNonEditable">›</span>' +
-	      '</span>',
+	      '</span> ',
 				'<w><ex rend="÷">word</ex></w>'
 	 		]
+		],
+		[ 'whole word <ex> tag (no w wrapper and words either side)',
+			[ '<w>first</w><ex rend="÷">word</ex><w>last</w>',
+				'first <span class="part_abbr" wce="__t=part_abbr&amp;__n=&amp;exp_rend_other=&amp;exp_rend=%C3%B7">' +
+				'<span class="format_start mceNonEditable">‹</span>(word)<span class="format_end mceNonEditable">›</span>' +
+				'</span> last ',
+				'<w>first</w><w><ex rend="÷">word</ex></w><w>last</w>'
+			]
 		],
     // not sure the next two are desireable behaviour but it is the current behaviour
     // fix this and at least keep the word [issue #14]
@@ -1049,4 +1058,16 @@ test ('node comparison', () => {
   expect(wce_tei.compareNodes(childList[3], childList[4])).toBe(true);
   expect(wce_tei.compareNodes(childList[4], childList[5])).toBe(false);
   expect(wce_tei.compareNodes(childList[0], childList[6])).toBe(false);
+});
+
+test ('hasWAncestor', () => {
+  const dom = wce_tei.loadXMLString('<text><body><w>word</w><ex>expansion</ex><w>pa<ex>rt</ex></w><w><unclear>unclear</unclear></w></body></text>');
+  const root = dom.documentElement;
+  const body = root.childNodes[0];
+	const childList = body.childNodes;
+  expect(wce_tei.hasWAncestor(childList[0])).toBe(true);
+	expect(wce_tei.hasWAncestor(childList[1])).toBe(false);
+	expect(wce_tei.hasWAncestor(childList[2])).toBe(true);
+	expect(wce_tei.hasWAncestor(childList[2])).toBe(true);
+	expect(wce_tei.hasWAncestor(body)).toBe(false);
 });

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -662,6 +662,11 @@ function getHtmlByTei(inputString) {
 		$newNode.setAttribute('wce', wceAttr);
 		addFormatElement($newNode);
 		$htmlParent.appendChild($newNode);
+		// legacy support
+		// add a space if the input was an <ex> without a <w> parent
+		if (!hasWAncestor($teiNode) ) {
+			nodeAddText($htmlParent, ' ');
+		}
 		return $newNode;
 	};
 	/*
@@ -4412,6 +4417,25 @@ function removeArrows(str) {
 	return out;
 };
 
+/** Recursive function to check if the given element has a <w> tag as an ancestor.
+
+@param {$node} element - The dom element node to check.
+@returns {boolean} - A boolean to indicate if w is present in the ancestors of the given node.
+
+*/
+function hasWAncestor($node) {
+	while ($node.nodeName != 'body') {
+		if ($node.nodeName == 'w') {
+			return true;
+		}
+		if (!$node.parentNode) {
+			return false;
+		}
+		return hasWAncestor($node.parentNode);
+	}
+	return false;
+}
+
 var removeBlankNode=function ($root){//remove blank node,
 		var _remove=function($node){
 			var nodeName=$node.nodeName;
@@ -4517,7 +4541,7 @@ var removeSpaceAfterLb=function ($node){
 
 	try {
 		module.exports = {
-		  startHasSpace, endHasSpace, addArrows, removeArrows, loadXMLString, getHtmlByTei,
+		  startHasSpace, endHasSpace, addArrows, removeArrows, hasWAncestor, loadXMLString, getHtmlByTei,
 			getTeiByHtml, Fehlerbehandlung, zeigeFehler, compareNodes
 		};
 	} catch (e) {


### PR DESCRIPTION
This is an addition to your ex tag changes which correctly ingests ex tags which are not within w tags. It works by adding a space in the html format in the editor when such a tag is loaded in which means that the output correctly wraps it in a w tag.

fixes #16 