### PR TITLE
stop removing words if hi has empty rend or does not have rend

### DIFF
--- a/__tests__/wce_tei.dom.test.js
+++ b/__tests__/wce_tei.dom.test.js
@@ -976,14 +976,14 @@ const teiToHtmlAndBackWithChange = new Map([
     // fix this and at least keep the word [issue #14]
     [ 'hi with no rend attribute removes the word with the hi tag',
       [ '<w>test</w><w><hi>for</hi></w><w>rendering</w>',
-        'test  rendering ',
-        '<w>test</w><w>rendering</w>'
+        'test for rendering ',
+        '<w>test</w><w>for</w><w>rendering</w>'
       ]
     ],
     [ 'hi with empty rend attribute removes the word with the hi tag',
       [ '<w>test</w><w><hi rend="">for</hi></w><w>rendering</w>',
-        'test  rendering ',
-        '<w>test</w><w>rendering</w>'
+        'test for rendering ',
+        '<w>test</w><w>for</w><w>rendering</w>'
       ]
     ],
     // legacy commentary notes (rend attribute - for number of lines covered - now converted to line breaks)

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -948,7 +948,8 @@ function getHtmlByTei(inputString) {
 		var $newNode = $newDoc.createElement('span');
 		var rendValue = $teiNode.getAttribute('rend');
 		if (!rendValue) {
-			return null;
+			nodeAddText($htmlParent, $teiNode.text);
+			return $htmlParent;
 		}
 
 		switch (rendValue) {


### PR DESCRIPTION
This ensures the contents of a hi tag which is missing its rend attribute is not removed from the dom on ingest. I think this is better that just silently removing the content.

fixes #14 