### PR TITLE
Jquery upgrade fix

### DIFF
--- a/__tests__/functional.test.js
+++ b/__tests__/functional.test.js
@@ -936,7 +936,7 @@ describe('testing with default client settings', () => {
      expect(await menuFrame.$eval('#supplied_source', el => el.value)).toBe('other');
      expect(await menuFrame.$eval('#supplied_source', el => el.disabled)).toBe(false);
      expect(await menuFrame.$eval('#supplied_source_other', el => el.disabled)).toBe(false);
-     expect(await menuFrame.$eval('#supplied_source_other', el => el.disabled)).toBe('nonsense');
+     expect(await menuFrame.$eval('#supplied_source_other', el => el.value)).toBe('nonsense');
 
 
 

--- a/wce-ote/plugin/js/wce.js
+++ b/wce-ote/plugin/js/wce.js
@@ -436,30 +436,34 @@ function writeWceNodeInfo(val) {
 function formUnserialize(str) {
 	$('input:checkbox').prop('checked', false);
 
-	if (str == null || str == '')
+	if (str == null || str == '') {
 		return;
+	}
 
 	var arr = str.split('&');
 	var kv, k, v;
 
 	for (var i = 2; i < arr.length; i++) {
-		kv = arr[i].split('=');
-		k = kv[0];
-		v = kv[1] == null ? '' : kv[1];
-		v = v.replace(/\+/g, ' ');
-
-		if ($('#' + k).attr('type') == 'checkbox') {
-			$('#' + k).prop('checked', true);
-		} else {
-			if (!v)
-				continue;
-			var dec_v = decodeURIComponent(v);
-			if (k == 'corrector_text' && corrector_text_editor) {
-				corrector_text_editor.setContent(dec_v);
-			} else if (k == 'marginals_text' && marginals_text_editor) {
-				marginals_text_editor.setContent(dec_v);
+		if (arr[i] !== '') {
+			kv = arr[i].split('=');
+			k = kv[0];
+			v = kv[1] == null ? '' : kv[1];
+			v = v.replace(/\+/g, ' ');
+	
+			if ($('#' + k).attr('type') == 'checkbox') {
+				$('#' + k).prop('checked', true);
+			} else {
+				if (!v) {
+					continue;
+				}
+				var dec_v = decodeURIComponent(v);
+				if (k == 'corrector_text' && corrector_text_editor) {
+					corrector_text_editor.setContent(dec_v);
+				} else if (k == 'marginals_text' && marginals_text_editor) {
+					marginals_text_editor.setContent(dec_v);
+				}
+				$('#' + k).val(dec_v);
 			}
-			$('#' + k).val(dec_v);
 		}
 	}
 }


### PR DESCRIPTION
While writing tests for the new gap default code I found a bug which I worked out was introduced by the jquery upgrade. The behaviour of one of the jquery functions seems to have changed which broke some instances of loading the forms when editing something like a gap. It is caused by two & one after the other in the html string containing all the data for the element. The two & have been there throughout they are just processed differently with the new jquery. 

I have fixed that in the wce.js code and added the tests I was writing to test the new gap behaviour into here to show that it is now working.

I am going to merge this straight away because I can't get any further with the gap defaults until this older bug is fixed.