### PR TITLE
code and tests to add a setting for default line number bar visibility

### DIFF
--- a/__tests__/default_functional_tests/appearance.tests.js
+++ b/__tests__/default_functional_tests/appearance.tests.js
@@ -116,4 +116,25 @@ describe('testing editor appearance', () => {
     expect(await frame.$eval('.mce-content-body', el => getComputedStyle(el).font)).toBe('24px / 48px GentiumPlus');
   });
 
+  test('check line number sidebar is visible on loading', async () => {
+    expect(await page.$eval('#wce_editor_wce_line_number', el => el.checked)).toBe(true);
+    expect(await page.$eval('.wce-linenumber-sidebar', el => getComputedStyle(el).display)).not.toBe('none');
+  });
+
+  test('check line number sidebar can be hidden and made visible again', async () => {
+    expect(await page.$eval('#wce_editor_wce_line_number', el => el.checked)).toBe(true);
+    expect(await page.$eval('.wce-linenumber-sidebar', el => getComputedStyle(el).display)).not.toBe('none');
+
+    // hide the sidebar
+    await page.click('input#wce_editor_wce_line_number');
+    expect(await page.$eval('#wce_editor_wce_line_number', el => el.checked)).toBe(false);
+    expect(await page.$eval('.wce-linenumber-sidebar', el => getComputedStyle(el).display)).toBe('none');
+
+    // show the sidebar
+    await page.click('input#wce_editor_wce_line_number');
+    expect(await page.$eval('#wce_editor_wce_line_number', el => el.checked)).toBe(true);
+    expect(await page.$eval('.wce-linenumber-sidebar', el => getComputedStyle(el).display)).not.toBe('none');
+  });
+
+
 });

--- a/__tests__/nondefault_functional_tests/appearance_nd.tests.js
+++ b/__tests__/nondefault_functional_tests/appearance_nd.tests.js
@@ -98,3 +98,40 @@ describe('testing with toolbar settings', () => {
     });
 
 });
+
+describe('testing with toolbar settings', () => {
+
+    beforeEach(async () => {
+        let frameHandle;
+        jest.setTimeout(5000000);
+        page = await browser.newPage();
+        await page.goto(`file:${path.join(__dirname, '../test_index_page.html')}`);
+        await page.evaluate(`setWceEditor('wce_editor', {showLineNumberSidebarOnLoading: false})`);
+        page.waitForSelector("#wce_editor_ifr");
+        frameHandle = null;
+        while (frameHandle === null) {
+            frameHandle = await page.$("iframe[id='wce_editor_ifr']");
+        }
+        frame = await frameHandle.contentFrame();
+    });
+
+    test('check line number sidebar is not visible on loading', async () => {
+        expect(await page.$eval('#wce_editor_wce_line_number', el => el.checked)).toBe(false);
+        expect(await page.$eval('.wce-linenumber-sidebar', el => getComputedStyle(el).display)).toBe('none');
+    });
+
+    test('check line number sidebar can be hidden and made visible again', async () => {
+        expect(await page.$eval('#wce_editor_wce_line_number', el => el.checked)).toBe(false);
+        expect(await page.$eval('.wce-linenumber-sidebar', el => getComputedStyle(el).display)).toBe('none');
+
+        // hide the sidebar
+        await page.click('input#wce_editor_wce_line_number');
+        expect(await page.$eval('#wce_editor_wce_line_number', el => el.checked)).toBe(true);
+        expect(await page.$eval('.wce-linenumber-sidebar', el => getComputedStyle(el).display)).not.toBe('none');
+
+        // show the sidebar
+        await page.click('input#wce_editor_wce_line_number');
+        expect(await page.$eval('#wce_editor_wce_line_number', el => el.checked)).toBe(false);
+        expect(await page.$eval('.wce-linenumber-sidebar', el => getComputedStyle(el).display)).toBe('none');
+    });
+});

--- a/wce-ote/plugin/plugin.js
+++ b/wce-ote/plugin/plugin.js
@@ -2868,7 +2868,7 @@
     					var linenumberCb='', lid;
 						if(ed.plugins.wcelinenumber){
 							linenumberCb='<input type="checkbox" style="margin-left:15px" ';
-							ed.settings.show_linenumber?(linenumberCb+='checked="checked"'):'';
+							ed.settings.clientOptions.showLineNumberSidebarOnLoading?(linenumberCb+='checked="checked"'):'';
 							lid=ed.id+'_wce_line_number';
 							linenumberCb+=' id="'+lid+'"> Show line number';
 						}
@@ -2884,9 +2884,9 @@
 
 						if(lid){
 							$('#'+lid).on('change', function(){
-								ed.execCommand('wceShowLineNumber',this.checked);
+								ed.execCommand('wceShowLineNumber', this.checked);
 							});
-							ed.execCommand('wceShowLineNumber',ed.settings.show_linenumber);
+							ed.execCommand('wceShowLineNumber', ed.settings.clientOptions.showLineNumberSidebarOnLoading);
 						}
     				}
     			});

--- a/wce-ote/wce_editor.js
+++ b/wce-ote/wce_editor.js
@@ -61,6 +61,7 @@
 @param {string} clientOptions.optionsForGapMenu.sourceOptions.labelEn - The visible label to use for this entry in the English interface.
 @param {string} clientOptions.optionsForGapMenu.sourceOptions.labelDe - The visible label to use for this entry in the German interface.
 @param {string} clientOptions.transcriptionLanguage - The css to use for the transcription in the editor. Choices are currently coptic and greek. Default is greek.
+@param {boolean} clientoptions.showLineNumberSidebarOnLoading - A boolean to determine if the line number sidebar should be shown on loading or not. Default is True
 @param {string} clientOptions.toolbar - The string to use to configure the toolbar. It should be a subset of the default provided, | put a divider at that point in the toolbar.
 @param {baseURL} string - Explicitly sets TinyMCE's base URL.
 @param {callback} function - The function to call once the editor is loaded.
@@ -105,6 +106,9 @@ function setWceEditor(_id, clientOptions, baseURL, callback) {
 														 {'value': 'na28','labelEn': 'NA28', 'labelDe': 'NA28'},
 														 {'value': 'tr','labelEn': 'Textus Receptus', 'labelDe': 'Textus Receptus'}];
 	}
+	if (!clientOptions.hasOwnProperty('showLineNumberSidebarOnLoading')) {
+		clientOptions.showLineNumberSidebarOnLoading = true;
+	}
 	
 	if (clientOptions.toolbar) {
 		toolbar = clientOptions.toolbar;
@@ -143,7 +147,6 @@ function setWceEditor(_id, clientOptions, baseURL, callback) {
 			'wcelinenumber': '../../wce-ote/plugin/js/line_number.js',
 			'wcecharmap': '../../wce-ote/plugin/js/wce_charmap.js'
 		},
-		show_linenumber:true,//default false,
 		ignoreShiftNotEn: (clientOptions.transcriptionLanguage == 'coptic') ? [] : [188, 190],
 		keyboardDebug: true,
 		init_instance_callback : "wceReload",


### PR DESCRIPTION
This changes the way the setting for line number visibility works. it used to be hard coded in the init part of tinymce but I have moved it to our client settings object so it can be set in the same way as the other settings. It just changes whether the line number bar is present when the editor loads, the user can still show and hide it by checking/unchecking the box. Fully tested.

Closes #102 