### PR TITLE
No xml id on notes

### DIFF
--- a/__tests__/default_functional_tests/marginalia_menu.tests.js
+++ b/__tests__/default_functional_tests/marginalia_menu.tests.js
@@ -411,7 +411,7 @@ describe('testing marginalia menu', () => {
         const htmlData = await page.evaluate(`getData()`);
         expect(htmlData).toBe('this is a title with a note<span class="paratext" wce_orig="" wce="__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=runTitle&amp;fw_type_other=&amp;covered=0&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=Title%20is%20here%3Cspan%20class%3D%22note%22%20wce_orig%3D%22%22%20wce%3D%22__t%3Dnote%26amp%3B__n%3D%26amp%3Bhelp%3DHelp%26amp%3Bnote_type%3Dlocal%26amp%3Bnote_type_other%3D%26amp%3BnewHand%3D%26amp%3Bnote_text%3DMy%2520note%22%3E%3Cspan%20class%3D%22format_start%20mceNonEditable%22%3E%E2%80%B9%3C%2Fspan%3ENote%3Cspan%20class%3D%22format_end%20mceNonEditable%22%3E%E2%80%BA%3C%2Fspan%3E%3C%2Fspan%3E&amp;number=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment="><span class="format_start mceNonEditable">‹</span>fw<span class="format_end mceNonEditable">›</span></span>');
         const xmlData = await page.evaluate(`getTEI()`);
-        expect(xmlData).toBe(xmlHead + '<w>this</w><w>is</w><w>a</w><w>title</w><w>with</w><w>a</w><w>note</w><fw type="runTitle"><w>Title</w><w>is</w><w>here</w><note type="local" xml:id="..--2">My note</note></fw>' + xmlTail);
+        expect(xmlData).toBe(xmlHead + '<w>this</w><w>is</w><w>a</w><w>title</w><w>with</w><w>a</w><w>note</w><fw type="runTitle"><w>Title</w><w>is</w><w>here</w><note type="local">My note</note></fw>' + xmlTail);
 
     });
 

--- a/__tests__/default_functional_tests/note_menu.tests.js
+++ b/__tests__/default_functional_tests/note_menu.tests.js
@@ -72,7 +72,7 @@ describe('testing notes menu', () => {
     const htmlData = await page.evaluate(`getData()`);
     expect(htmlData).toBe('a note<span class=\"note\" wce_orig=\"\" wce=\"__t=note&amp;__n=&amp;help=Help&amp;note_type=local&amp;note_type_other=&amp;newHand=&amp;note_text=my%20new%20local%20note\"><span class=\"format_start mceNonEditable\">‹</span>Note<span class=\"format_end mceNonEditable\">›</span></span>');
     const xmlData = await page.evaluate(`getTEI()`);
-    expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="local" xml:id="..--2">my new local note</note>' + xmlTail);
+    expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="local">my new local note</note>' + xmlTail);
   }, 200000);
 
   test('a handShift note', async () => {
@@ -92,7 +92,7 @@ describe('testing notes menu', () => {
     const htmlData = await page.evaluate(`getData()`);
     expect(htmlData).toBe('a note<span class=\"note\" wce_orig=\"\" wce=\"__t=note&amp;__n=&amp;help=Help&amp;note_type=changeOfHand&amp;note_type_other=&amp;newHand=&amp;note_text=\"><span class=\"format_start mceNonEditable\">‹</span>Note<span class=\"format_end mceNonEditable\">›</span></span>');
     const xmlData = await page.evaluate(`getTEI()`);
-    expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="editorial" xml:id="..--2"><handShift/></note>' + xmlTail);
+    expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="editorial"><handShift/></note>' + xmlTail);
   }, 200000);
 
   test('a handShift note with new hand', async () => {
@@ -113,7 +113,7 @@ describe('testing notes menu', () => {
     const htmlData = await page.evaluate(`getData()`);
     expect(htmlData).toBe('a note<span class=\"note\" wce_orig=\"\" wce=\"__t=note&amp;__n=&amp;help=Help&amp;note_type=changeOfHand&amp;note_type_other=&amp;newHand=new%20hand&amp;note_text=\"><span class=\"format_start mceNonEditable\">‹</span>Note<span class=\"format_end mceNonEditable\">›</span></span>');
     const xmlData = await page.evaluate(`getTEI()`);
-    expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="editorial" xml:id="..--2"><handShift scribe="new hand"/></note>' + xmlTail);
+    expect(xmlData).toBe(xmlHead + '<w>a</w><w>note</w><note type="editorial"><handShift scribe="new hand"/></note>' + xmlTail);
   }, 200000);
 
 });

--- a/__tests__/wce_tei.dom.test.js
+++ b/__tests__/wce_tei.dom.test.js
@@ -83,16 +83,16 @@ const basicAnnotation = new Map([
 	// abbr
 	[ 'nomen sacrum abbreviation with overline',
 		[ '<w>a</w><w><abbr type="nomSac"><hi rend="overline">ns</hi></abbr></w><w>abbreviation</w>',
-			'a <span class=\"abbr_add_overline\" wce=\"__t=abbr&amp;__n=&amp;original_abbr_text=&amp;' +
-			'add_overline=overline&amp;abbr_type_other=&amp;abbr_type=nomSac\" wce_orig=\"ns\">' +
-			'<span class=\"format_start mceNonEditable\">‹</span>ns<span class=\"format_end mceNonEditable\">›</span>' +
+			'a <span class="abbr_add_overline" wce="__t=abbr&amp;__n=&amp;original_abbr_text=&amp;' +
+			'add_overline=overline&amp;abbr_type_other=&amp;abbr_type=nomSac" wce_orig="ns">' +
+			'<span class="format_start mceNonEditable">‹</span>ns<span class="format_end mceNonEditable">›</span>' +
 			'</span> abbreviation '
 		]
 	],
 	// // supplied in abbr - this isn't hitting what I expected
 	// [ 'supplied text in nomsac',
 	//   [ '<w>supplied</w><w>text</w><w>in</w><w><abbr type="nomSac"><hi rend="overline">nom<supplied source="transcriber" reason="illegible">sac</supplied></hi></abbr></w>',
-	//     'supplied text in <span class=\"abbr_add_overline\" wce=\"__t=abbr&amp;__n=&amp;original_abbr_text=&amp;add_overline=overline&amp;abbr_type_other=&amp;abbr_type=nomSac\" wce_orig=\"nom%3Cspan%20class%3D%22gap%22%20wce_orig%3D%22sac%22%20wce%3D%22__t%3Dgap%26amp%3B__n%3D%26amp%3Bgap_reason_dummy_lacuna%3Dlacuna%26amp%3Bgap_reason_dummy_illegible%3Dillegible%26amp%3Bgap_reason_dummy_unspecified%3Dunspecified%26amp%3Bgap_reason_dummy_inferredPage%3DinferredPage%26amp%3Bsupplied_source_other%3D%26amp%3Bsupplied_source%3Dtranscriber%26amp%3Bgap_reason%3Dillegible%26amp%3Bunit_other%3D%26amp%3Bunit%3D%26amp%3Bmark_as_supplied%3Dsupplied%22%3E%3Cspan%20class%3D%22format_start%20mceNonEditable%22%3E%E2%80%B9%3C%2Fspan%3E%5Bsac%5D%3Cspan%20class%3D%22format_end%20mceNonEditable%22%3E%E2%80%BA%3C%2Fspan%3E%3C%2Fspan%3E\"><span class=\"format_start mceNonEditable\">‹</span>nom<span class=\"gap\" wce_orig=\"sac\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;supplied_source_other=&amp;supplied_source=transcriber&amp;gap_reason=illegible&amp;unit_other=&amp;unit=&amp;mark_as_supplied=supplied\"><span class=\"format_start mceNonEditable\">‹</span>[sac]<span class=\"format_end mceNonEditable\">›</span></span><span class=\"format_end mceNonEditable\">›</span></span> '
+	//     'supplied text in <span class="abbr_add_overline" wce="__t=abbr&amp;__n=&amp;original_abbr_text=&amp;add_overline=overline&amp;abbr_type_other=&amp;abbr_type=nomSac" wce_orig="nom%3Cspan%20class%3D%22gap%22%20wce_orig%3D%22sac%22%20wce%3D%22__t%3Dgap%26amp%3B__n%3D%26amp%3Bgap_reason_dummy_lacuna%3Dlacuna%26amp%3Bgap_reason_dummy_illegible%3Dillegible%26amp%3Bgap_reason_dummy_unspecified%3Dunspecified%26amp%3Bgap_reason_dummy_inferredPage%3DinferredPage%26amp%3Bsupplied_source_other%3D%26amp%3Bsupplied_source%3Dtranscriber%26amp%3Bgap_reason%3Dillegible%26amp%3Bunit_other%3D%26amp%3Bunit%3D%26amp%3Bmark_as_supplied%3Dsupplied%22%3E%3Cspan%20class%3D%22format_start%20mceNonEditable%22%3E%E2%80%B9%3C%2Fspan%3E%5Bsac%5D%3Cspan%20class%3D%22format_end%20mceNonEditable%22%3E%E2%80%BA%3C%2Fspan%3E%3C%2Fspan%3E"><span class="format_start mceNonEditable">‹</span>nom<span class="gap" wce_orig="sac" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;supplied_source_other=&amp;supplied_source=transcriber&amp;gap_reason=illegible&amp;unit_other=&amp;unit=&amp;mark_as_supplied=supplied"><span class="format_start mceNonEditable">‹</span>[sac]<span class="format_end mceNonEditable">›</span></span><span class="format_end mceNonEditable">›</span></span> '
 	//   ]
 	// ],
 	// this seems like overkill in the html doesn't it?
@@ -100,25 +100,25 @@ const basicAnnotation = new Map([
 		[ '<w><supplied source="na28" reason="illegible">a</supplied></w><w><supplied source="na28" reason="illegible">' +
 			'<abbr type="nomSac"><hi rend="overline">ns</hi></abbr></supplied></w>' +
 			'<w><supplied source="na28" reason="illegible">abbreviation</supplied></w>',
-			'<span class=\"gap\" wce_orig=\"a%20%3Cspan%20class%3D%22abbr_add_overline%22%20wce%3D%22__t%3Dabbr%26amp%' +
+			'<span class="gap" wce_orig="a%20%3Cspan%20class%3D%22abbr_add_overline%22%20wce%3D%22__t%3Dabbr%26amp%' +
 			'3B__n%3D%26amp%3Boriginal_abbr_text%3D%26amp%3Badd_overline%3Doverline%26amp%3Babbr_type_other%3D%26amp%3B' +
 			'abbr_type%3DnomSac%22%20wce_orig%3D%22ns%22%3E%3Cspan%20class%3D%22format_start%20mceNonEditable' +
 			'%22%3E%E2%80%B9%3C%2Fspan%3Ens%3Cspan%20class%3D%22format_end%20mceNonEditable%22%3E%E2%80%BA%3C%2Fspan' +
-			'%3E%3C%2Fspan%3E%20abbreviation\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
+			'%3E%3C%2Fspan%3E%20abbreviation" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
 			'gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;' +
 			'gap_reason_dummy_inferredPage=inferredPage&amp;supplied_source_other=&amp;supplied_source=na28&amp;' +
-			'gap_reason=illegible&amp;unit_other=&amp;unit=&amp;mark_as_supplied=supplied\">' +
-			'<span class=\"format_start mceNonEditable\">‹</span>[a <span class=\"abbr_add_overline\" wce=\"__t=abbr&amp;' +
+			'gap_reason=illegible&amp;unit_other=&amp;unit=&amp;mark_as_supplied=supplied">' +
+			'<span class="format_start mceNonEditable">‹</span>[a <span class="abbr_add_overline" wce="__t=abbr&amp;' +
 			'__n=&amp;original_abbr_text=&amp;add_overline=overline&amp;abbr_type_other=&amp;' +
-			'abbr_type=nomSac\" wce_orig=\"ns\"><span class=\"format_start mceNonEditable\">‹</span>ns' +
-			'<span class=\"format_end mceNonEditable\">›</span></span> abbreviation]<span class=\"format_end mceNonEditable\">›</span></span> '
+			'abbr_type=nomSac" wce_orig="ns"><span class="format_start mceNonEditable">‹</span>ns' +
+			'<span class="format_end mceNonEditable">›</span></span> abbreviation]<span class="format_end mceNonEditable">›</span></span> '
 		]
 	],
 	// special his with extra details not covered in separate simpler tests below
   [ 'capitals',
     [ '<w><hi rend="cap" height="3">I</hi>nitial</w><w>capital</w>',
-      '<span class=\"formatting_capitals\" wce=\"__t=formatting_capitals&amp;__n=&amp;capitals_height=3\" wce_orig=\"I\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span>I<span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="formatting_capitals" wce="__t=formatting_capitals&amp;__n=&amp;capitals_height=3" wce_orig="I">' +
+      '<span class="format_start mceNonEditable">‹</span>I<span class="format_end mceNonEditable">›</span>' +
       '</span>nitial capital '
     ]
   ],
@@ -212,10 +212,10 @@ const gapAndSupplied = new Map([
   ],
   [ 'gap between words no details given',
     [ '<w>this</w><gap/><w>continues</w>',
-      'this <span class=\"gap\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
+      'this <span class="gap" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
       'gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;' +
-      'gap_reason_dummy_inferredPage=inferredPage&amp;unit_other=&amp;unit=\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span>[...]<span class=\"format_end mceNonEditable\">›</span>' +
+      'gap_reason_dummy_inferredPage=inferredPage&amp;unit_other=&amp;unit=">' +
+      '<span class="format_start mceNonEditable">‹</span>[...]<span class="format_end mceNonEditable">›</span>' +
       '</span> continues '
     ]
   ],
@@ -229,43 +229,43 @@ const gapAndSupplied = new Map([
   ],
   [ 'gap within word no unit given',
     [ '<w>wo<gap reason="illegible"/></w>',
-      'wo<span class=\"gap\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
+      'wo<span class="gap" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
       'gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;' +
-      'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;unit=\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span>[...]<span class=\"format_end mceNonEditable\">›</span></span> '
+      'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;unit=">' +
+      '<span class="format_start mceNonEditable">‹</span>[...]<span class="format_end mceNonEditable">›</span></span> '
     ]
   ],
   [ 'gap with unit char and no extent given',
     [ '<w>wo<gap reason="illegible" unit="char"/></w>',
-      'wo<span class=\"gap\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
+      'wo<span class="gap" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
 			'gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;' +
-			'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;unit=char\">' +
-			'<span class=\"format_start mceNonEditable\">‹</span>[...]<span class=\"format_end mceNonEditable\">›</span></span> '
+			'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;unit=char">' +
+			'<span class="format_start mceNonEditable">‹</span>[...]<span class="format_end mceNonEditable">›</span></span> '
     ]
   ],
   [ 'gap with unit line and no extent given',
     [ '<w>missing</w><w>line</w><gap reason="illegible" unit="line"/>',
-      'missing line <span class=\"gap\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
+      'missing line <span class="gap" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
 			'gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;' +
-			'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;unit=line\"/>'
+			'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;unit=line"/>'
     ]
   ],
   [ 'gap with unit line and extent part',
     [ '<w>missing</w><w>line</w><gap reason="illegible" unit="line" extent="part"/>',
-      'missing line <span class=\"gap\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
+      'missing line <span class="gap" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
 			'gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;' +
 			'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;unit=line&amp;' +
-			'extent=part\"><span class=\"format_start mceNonEditable\">‹</span>[...]' +
-			'<span class=\"format_end mceNonEditable\">›</span></span>'
+			'extent=part"><span class="format_start mceNonEditable">‹</span>[...]' +
+			'<span class="format_end mceNonEditable">›</span></span>'
     ]
   ],
   [ 'gap with unit line and extent unspecified',
     [ '<w>missing</w><w>line</w><gap reason="illegible" unit="line" extent="unspecified"/>',
-      'missing line <span class=\"gap\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
+      'missing line <span class="gap" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
 			'gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;' +
 			'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;unit=line&amp;' +
-			'extent=unspecified\"><span class=\"format_start mceNonEditable\">‹</span>[...]' +
-			'<span class=\"format_end mceNonEditable\">›</span></span>'
+			'extent=unspecified"><span class="format_start mceNonEditable">‹</span>[...]' +
+			'<span class="format_end mceNonEditable">›</span></span>'
     ]
   ],
   [ 'missing quire',
@@ -478,7 +478,7 @@ const notes = new Map([
   // notes
   // another undefined issue
   [ 'a local note',
-    [ '<w>a</w><w>note</w><note type="local" xml:id="..-undefined-2">my new local note</note>',
+    [ '<w>a</w><w>note</w><note type="local">my new local note</note>',
       'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=my%20new%20local%20note&amp;' +
       'note_type=local&amp;newhand="><span class="format_start mceNonEditable">‹</span>Note' +
       '<span class="format_end mceNonEditable">›</span></span>'
@@ -486,7 +486,7 @@ const notes = new Map([
   ],
   // a handshift note - needs to be changed to handShift [issue #12]
   [ 'a handShift note',
-    [ '<w>a</w><w>note</w><note type="editorial" xml:id="..-undefined-2"><handShift/></note>',
+    [ '<w>a</w><w>note</w><note type="editorial"><handShift/></note>',
       'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
       'note_type_other=&amp;newHand="><span class="format_start mceNonEditable">‹</span>Note' +
       '<span class="format_end mceNonEditable">›</span></span>'
@@ -494,7 +494,7 @@ const notes = new Map([
   ],
   // spaces added in attribute should be replaced with _ [issue #13]
   [ 'a handShift note with new hand',
-    [ '<w>a</w><w>note</w><note type="editorial" xml:id="..-undefined-2"><handShift scribe="new hand"/></note>',
+    [ '<w>a</w><w>note</w><note type="editorial"><handShift scribe="new hand"/></note>',
       'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
       'note_type_other=&amp;newHand=new%20hand"><span class="format_start mceNonEditable">‹</span>Note' +
       '<span class="format_end mceNonEditable">›</span></span>'
@@ -530,11 +530,11 @@ const notes = new Map([
   // again there is code for this in the note function but this seems to use the paratext one (notes stuff claims to be legacy)
   [ 'lectionary in line',
     [ '<w>in</w><w>line</w><w>lectionary</w><note type="lectionary-other">Untranscribed lectionary text within the line</note>',
-      'in line lectionary<span class=\"paratext\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;' +
+      'in line lectionary<span class="paratext" wce="__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;' +
 			'covered=0&amp;text=&amp;number=&amp;edit_number=on&amp;paratext_position=pagetop&amp;' +
-			'paratext_position_other=&amp;paratext_alignment=left\"><span class=\"format_start mceNonEditable\">‹</span>' +
-			'[<span class=\"lectionary-other\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;' +
-			'covered=0\">lect</span>]<span class=\"format_end mceNonEditable\">›</span></span>'
+			'paratext_position_other=&amp;paratext_alignment=left"><span class="format_start mceNonEditable">‹</span>' +
+			'[<span class="lectionary-other" wce="__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;' +
+			'covered=0">lect</span>]<span class="format_end mceNonEditable">›</span></span>'
     ]
   ],
   [ '2 lines of untranscribed lectionary text',
@@ -589,14 +589,14 @@ const fw = new Map([
 const embeddedMenuData = new Map([
   // running title in centre of top margin
   [ 'running title (fw) in centre top margin (seg)',
-    [ '<w>This</w><w>is</w><w>a</w><w>title</w><w>with</w><w>a</w><w>note</w><fw type=\"runTitle\"><w>my</w>' +
-      '<w>title</w><note type=\"local\" xml:id=\"..-undefined-2\">My note</note></fw>',
-      'This is a title with a note <span class=\"paratext\" wce=\"__t=paratext&amp;__n=&amp;marginals_text=' +
+    [ '<w>This</w><w>is</w><w>a</w><w>title</w><w>with</w><w>a</w><w>note</w><fw type="runTitle"><w>my</w>' +
+      '<w>title</w><note type="local">My note</note></fw>',
+      'This is a title with a note <span class="paratext" wce="__t=paratext&amp;__n=&amp;marginals_text=' +
       'my%20title%3Cspan%20class%3D%22note%22%20wce%3D%22__t%3Dnote%26amp%3B__n%3D%26amp%3Bnote_text%3DMy%2520' +
       'note%26amp%3Bnote_type%3Dlocal%26amp%3Bnewhand%3D%22%3E%3Cspan%20class%3D%22format_start%20mceNonEditable' +
       '%22%3E%E2%80%B9%3C%2Fspan%3ENote%3Cspan%20class%3D%22format_end%20mceNonEditable%22%3E%E2%80%BA%3C%2Fspan' +
-      '%3E%3C%2Fspan%3E&amp;fw_type=runTitle&amp;paratext_position=&amp;paratext_position_other=\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span>fw<span class=\"format_end mceNonEditable\">›</span></span>'
+      '%3E%3C%2Fspan%3E&amp;fw_type=runTitle&amp;paratext_position=&amp;paratext_position_other=">' +
+      '<span class="format_start mceNonEditable">‹</span>fw<span class="format_end mceNonEditable">›</span></span>'
     ]
   ]
 ]);
@@ -816,60 +816,60 @@ const manuscriptPageStructure = new Map([
   [ 'initial page, using type=folio',
     [ '<pb n="1r" type="folio" xml:id="P1r-undefined"/><cb n="P1rC1-undefined"/>' +
       '<lb n="P1rC1L-undefined"/><w>my</w><w>first</w><w>page</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=r&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1r<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=r&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1r<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span> my first page '
     ]
   ],
   [ 'initial page, using type=folio, with facsimile',
     [ '<pb n="1r" type="folio" facs="http://thelibrary/image7.jpg" xml:id="P1r-undefined"/><cb n="P1rC1-undefined"/>' +
       '<lb n="P1rC1L-undefined"/><w>my</w><w>first</w><w>page</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=r&amp;fibre_type=&amp;facs=http://thelibrary/image7.jpg&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1r<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=r&amp;fibre_type=&amp;facs=http://thelibrary/image7.jpg&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1r<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span> my first page '
     ]
   ],
   [ 'mid-text page, using type=page',
     [ '<w>end</w><w>of</w><w>page</w><pb n="1" type="page" xml:id="P1-undefined"/><cb n="P1C1-undefined"/>' +
       '<lb n="P1C1L-undefined"/><w>my</w><w>second</w><w>page</w>',
-      'end of page <span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=pb&amp;number=1&amp;rv=&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      'end of page <span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=pb&amp;number=1&amp;rv=&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span> my second page '
     ]
   ],
   [ 'mid-word page, for papyri (type=page and y)',
     [ '<w>half</w><w>of</w><w>wo<pb n="1↓" type="page" xml:id="P1y-undefined" break="no"/><cb n="P1yC1-undefined"/>' +
       '<lb n="P1yC1L-undefined"/>rd</w><w>on</w><w>second</w><w>page</w>',
-      'half of wo<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=pb&amp;number=1&amp;rv=&amp;fibre_type=y&amp;facs=&amp;lb_alignment=&amp;hasBreak=yes\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span>-<br/>PB 1y<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      'half of wo<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=pb&amp;number=1&amp;rv=&amp;fibre_type=y&amp;facs=&amp;lb_alignment=&amp;hasBreak=yes">' +
+      '<span class="format_start mceNonEditable">‹</span>-<br/>PB 1y<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span>rd on second page '
     ]
   ],
@@ -877,21 +877,21 @@ const manuscriptPageStructure = new Map([
     [ '<pb n="1v" type="folio" xml:id="P1v-undefined"/><cb n="P1vC1-undefined"/><lb n="P1vC1L-undefined"/>' +
       '<w>my</w><w>first</w><w>column</w><cb n="P1vC2-undefined"/><lb n="P1vC2L-undefined"/>' +
       '<w>my</w><w>second</w><w>column</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=v&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1v<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-      '</span> my first column <span class=\"mceNonEditable brea\" id=\"cb_2_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=2&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 2<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_2_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=v&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1v<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+      '</span> my first column <span class="mceNonEditable brea" id="cb_2_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=2&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 2<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_2_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span> my second column '
     ]
   ],
@@ -899,128 +899,128 @@ const manuscriptPageStructure = new Map([
     [ '<pb n="1v" type="folio" xml:id="P1v-undefined"/><cb n="P1vC1-undefined"/><lb n="P1vC1L-undefined"/>' +
       '<w>my</w><w>first</w><w>colu<cb n="P1vC2-undefined" break="no"/><lb n="P1vC2L-undefined"/>mn</w>' +
       '<w>my</w><w>second</w><w>column</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=v&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1v<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-      '</span> my first colu<span class=\"mceNonEditable brea\" id=\"cb_2_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=2&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=yes\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span>-<br/>CB 2<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_2_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=v&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1v<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+      '</span> my first colu<span class="mceNonEditable brea" id="cb_2_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=2&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=yes">' +
+      '<span class="format_start mceNonEditable">‹</span>-<br/>CB 2<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_2_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span>mn my second column '
     ]
   ],
   [ 'between-word linebreak',
     [ '<pb n="1" type="page" xml:id="P1-undefined"/><cb n="P1C1-undefined"/><lb n="P1C1L-undefined"/>' +
       '<w>my</w><w>first</w><w>line</w><lb n="P1C1L-undefined"/><w>my</w><w>second</w><w>line</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-      '</span> my first line <span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+      '</span> my first line <span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span> my second line '
     ]
   ],
   [ 'between-word linebreak, hanging line',
     [ '<pb n="1" type="page" xml:id="P1-undefined"/><cb n="P1C1-undefined"/><lb n="P1C1L-undefined"/>' +
       '<w>my</w><w>first</w><w>line</w><lb n="P1C1L-undefined" rend="hang"/><w>my</w><w>second</w><w>line</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-      '</span> my first line <span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;break_type=lb&amp;' +
-      'number=&amp;lb_alignment=hang&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵← <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+      '</span> my first line <span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;break_type=lb&amp;' +
+      'number=&amp;lb_alignment=hang&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵← <span class="format_end mceNonEditable">›</span>' +
       '</span> my second line '
     ]
   ],
   [ 'between-word linebreak, indented line',
     [ '<pb n="1" type="page" xml:id="P1-undefined"/><cb n="P1C1-undefined"/><lb n="P1C1L-undefined"/>' +
       '<w>my</w><w>first</w><w>line</w><lb n="P1C1L-undefined" rend="indent"/><w>my</w><w>second</w><w>line</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-      '</span> my first line <span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;break_type=lb&amp;' +
-      'number=&amp;lb_alignment=indent&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵→ <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+      '</span> my first line <span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;break_type=lb&amp;' +
+      'number=&amp;lb_alignment=indent&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵→ <span class="format_end mceNonEditable">›</span>' +
       '</span> my second line '
     ]
   ],
   [ 'mid-word linebreak',
     [ '<pb n="1v" type="folio" xml:id="P1v-undefined"/><cb n="P1vC1-undefined"/><lb n="P1vC1L-undefined"/><w>my</w><w>first</w><w>li' +
       '<lb n="P1vC1L-undefined" break="no"/>ne</w><w>my</w><w>second</w><w>line</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=v&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1v<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-      '</span> my first li<span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;break_type=lb&amp;' +
-      'number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=yes\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span>-<br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=v&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1v<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+      '</span> my first li<span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;break_type=lb&amp;' +
+      'number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=yes">' +
+      '<span class="format_start mceNonEditable">‹</span>-<br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span>ne my second line '
     ]
   ],
   [ 'mid-word linebreak with rend attribute',
     [ '<pb n="1v" type="folio" xml:id="P1v-undefined"/><cb n="P1vC1-undefined"/><lb n="P1vC1L-undefined"/><w>my</w><w>first</w><w>li' +
       '<lb n="P1vC1L-undefined" rend="hang" break="no"/>ne</w><w>my</w><w>second</w><w>line</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;' +
-      'number=1&amp;rv=v&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1v<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-      '</span> my first li<span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;break_type=lb&amp;' +
-      'number=&amp;lb_alignment=hang&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=yes\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span>-<br/>↵← <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=pb&amp;' +
+      'number=1&amp;rv=v&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1v<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+      '</span> my first li<span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;break_type=lb&amp;' +
+      'number=&amp;lb_alignment=hang&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=yes">' +
+      '<span class="format_start mceNonEditable">‹</span>-<br/>↵← <span class="format_end mceNonEditable">›</span>' +
       '</span>ne my second line '
     ],
   ],
   [ 'quire break',
     [ '<gb n="3"/><pb n="1r" type="folio" xml:id="P1r-undefined"/><cb n="P1rC1-undefined"/><lb n="P1rC1L-undefined"/>',
-      '<span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;break_type=gb&amp;number=3&amp;' +
-			'lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-			'<span class=\"format_start mceNonEditable\">‹</span><br/>QB<span class=\"format_end mceNonEditable\">›</span>' +
-			'</span><span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-			'break_type=pb&amp;number=1&amp;rv=r&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-			'<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1r<span class=\"format_end mceNonEditable\">›</span>' +
-			'</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-			'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-			'<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-			'</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-			'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-			'<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span></span>'
+      '<span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;break_type=gb&amp;number=3&amp;' +
+			'lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+			'<span class="format_start mceNonEditable">‹</span><br/>QB<span class="format_end mceNonEditable">›</span>' +
+			'</span><span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+			'break_type=pb&amp;number=1&amp;rv=r&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+			'<span class="format_start mceNonEditable">‹</span><br/>PB 1r<span class="format_end mceNonEditable">›</span>' +
+			'</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+			'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+			'<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+			'</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+			'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+			'<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span></span>'
     ]
   ]
 ]);
@@ -1075,29 +1075,29 @@ const teiToHtmlAndBackWithChange = new Map([
       ]
     ],
     [ 'a handShift note with new hand, legacy for when new hand was in n attribute',
-      [ '<w>a</w><w>note</w><note type="editorial" xml:id="..-undefined-2"><handshift n="new hand"/></note>',
+      [ '<w>a</w><w>note</w><note type="editorial"><handshift n="new hand"/></note>',
         'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
         'note_type_other=&amp;newHand=new%20hand"><span class="format_start mceNonEditable">‹</span>Note' +
         '<span class="format_end mceNonEditable">›</span></span>',
-        '<w>a</w><w>note</w><note type="editorial" xml:id="..-undefined-2"><handShift scribe="new hand"/></note>'
+        '<w>a</w><w>note</w><note type="editorial"><handShift scribe="new hand"/></note>'
       ]
     ],
 		// legacy support
 	  [ 'a handShift note',
-	    [ '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handshift/></note>',
+	    [ '<w>a</w><w>note</w><note type="editorial"><handshift/></note>',
 	      'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
 	      'note_type_other=&amp;newHand="><span class="format_start mceNonEditable">‹</span>Note' +
 	      '<span class="format_end mceNonEditable">›</span></span>',
-				'<w>a</w><w>note</w><note type="editorial" xml:id="..-undefined-2"><handShift/></note>'
+				'<w>a</w><w>note</w><note type="editorial"><handShift/></note>'
 	    ]
 	  ],
 	  // spaces added in attribute should be replaced with _ [issue #13]
 	  [ 'a handShift note with new hand',
-	    [ '<w>a</w><w>note</w><note type="editorial" xml:id="BKV-undefined-2"><handshift scribe="new hand"/></note>',
+	    [ '<w>a</w><w>note</w><note type="editorial"><handshift scribe="new hand"/></note>',
 	      'a note<span class="note" wce="__t=note&amp;__n=&amp;note_text=&amp;note_type=changeOfHand&amp;' +
 	      'note_type_other=&amp;newHand=new%20hand"><span class="format_start mceNonEditable">‹</span>Note' +
 	      '<span class="format_end mceNonEditable">›</span></span>',
-				'<w>a</w><w>note</w><note type="editorial" xml:id="..-undefined-2"><handShift scribe="new hand"/></note>',
+				'<w>a</w><w>note</w><note type="editorial"><handShift scribe="new hand"/></note>',
 	    ]
 	  ],
     [ 'hi rend ol as legacy support for overline',
@@ -1154,14 +1154,14 @@ const teiToHtmlAndBackWithChange = new Map([
     ],
     [ 'lectionary in line with rend attribute',
       [ '<w>in</w><w>line</w><w>lectionary</w><note type="lectionary-other" rend="3">Lectionary text within the line</note>',
-        'in line lectionary<span class=\"paratext\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=3&amp;text=&amp;number=&amp;edit_number=on&amp;paratext_position=pagetop&amp;paratext_position_other=&amp;paratext_alignment=left\"><span class=\"format_start mceNonEditable\">‹</span><br/>↵[<span class=\"lectionary-other\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=3\">lect</span>]<br/>↵[<span class=\"lectionary-other\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=3\">lect</span>]<br/>↵[<span class=\"lectionary-other\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=3\">lect</span>]<span class=\"format_end mceNonEditable\">›</span></span>',
-        '<w>in</w><w>line</w><w>lectionary</w><lb/><note type=\"lectionary-other\">One line of untranscribed lectionary text</note><lb/><note type=\"lectionary-other\">One line of untranscribed lectionary text</note><lb/><note type=\"lectionary-other\">One line of untranscribed lectionary text</note>'
+        'in line lectionary<span class="paratext" wce="__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=3&amp;text=&amp;number=&amp;edit_number=on&amp;paratext_position=pagetop&amp;paratext_position_other=&amp;paratext_alignment=left"><span class="format_start mceNonEditable">‹</span><br/>↵[<span class="lectionary-other" wce="__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=3">lect</span>]<br/>↵[<span class="lectionary-other" wce="__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=3">lect</span>]<br/>↵[<span class="lectionary-other" wce="__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=3">lect</span>]<span class="format_end mceNonEditable">›</span></span>',
+        '<w>in</w><w>line</w><w>lectionary</w><lb/><note type="lectionary-other">One line of untranscribed lectionary text</note><lb/><note type="lectionary-other">One line of untranscribed lectionary text</note><lb/><note type="lectionary-other">One line of untranscribed lectionary text</note>'
       ]
     ],
 		// legacy support for referencing system
 		[ 'book, chapter and verse (legacy)',
 	    [ '<div type="book" n="B04"><div type="chapter" n="B04K1"><ab n="B04K1V1"><w>first</w><w>verse</w></ab></div></div>',
-	      ' <span class=\"book_number mceNonEditable\" wce=\"__t=book_number\" id=\"1\">John</span>  <span class=\"chapter_number mceNonEditable\" wce=\"__t=chapter_number\" id=\"2\">1</span> <span class=\"verse_number mceNonEditable\" wce=\"__t=verse_number\">1</span> first verse ',
+	      ' <span class="book_number mceNonEditable" wce="__t=book_number" id="1">John</span>  <span class="chapter_number mceNonEditable" wce="__t=chapter_number" id="2">1</span> <span class="verse_number mceNonEditable" wce="__t=verse_number">1</span> first verse ',
 				'<div type="book" n="John"><div type="chapter" n="John.1"><ab n="John.1.1"><w>first</w><w>verse</w></ab></div></div>'
 	    ]
 	  ],
@@ -1206,6 +1206,13 @@ const teiToHtmlAndBackWithChange = new Map([
         '<span class="verse_number mceNonEditable" wce="__t=verse_number"/> subscriptio text ',
         '<div type="book" n="John"><div type="subscriptio"><ab n="John.subscriptio"><w>subscriptio</w><w>text</w></ab></div></div>'
       ]
+    ],
+    // legacy support for xml:id on notes (just needs to not break if it gets them)
+    [ 'note with an xml:id',
+      ['<note type="editorial" xml:id="B04K1V2-01-1">My note</note>',
+       '<span class="note" wce="__t=note&amp;__n=&amp;note_text=My%20note&amp;note_type=editorial&amp;newhand="><span class="format_start mceNonEditable">‹</span>Note<span class="format_end mceNonEditable">›</span></span>',
+       '<note type="editorial">My note</note>'
+      ]
     ]
 ]);
 
@@ -1230,26 +1237,26 @@ teiToHtmlAndBackWithChange.forEach((value, key, map) => {
 const exportSpaces = new Map([
   [ 'test spaces are added to export w and pc',
     ['<w>test</w><w>word</w>spaces<w></w><pc>.</pc><w>with</w><w>punctuation</w><pc>.</pc>',
-     'test word spaces <span class=\"pc\" wce=\"__t=pc\"><span class=\"format_start mceNonEditable\">‹</span>.' +
-     '<span class=\"format_end mceNonEditable\">›</span></span> with punctuation <span class=\"pc\" wce=\"__t=pc\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span>.<span class=\"format_end mceNonEditable\">›</span></span> ',
+     'test word spaces <span class="pc" wce="__t=pc"><span class="format_start mceNonEditable">‹</span>.' +
+     '<span class="format_end mceNonEditable">›</span></span> with punctuation <span class="pc" wce="__t=pc">' +
+     '<span class="format_start mceNonEditable">‹</span>.<span class="format_end mceNonEditable">›</span></span> ',
      '<w>test</w> <w>word</w> <w>spaces</w><pc>.</pc> <w>with</w> <w>punctuation</w><pc>.</pc>'
     ]
   ],
   [ 'test spaces can be uploaded and exported without problems w and pc',
     ['<w>test</w> <w>word</w> <w>spaces</w><pc>.</pc> <w>with</w> <w>punctuation</w><pc>.</pc>',
-     'test word spaces <span class=\"pc\" wce=\"__t=pc\"><span class=\"format_start mceNonEditable\">‹</span>.' +
-     '<span class=\"format_end mceNonEditable\">›</span></span> with punctuation <span class=\"pc\" wce=\"__t=pc\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span>.<span class=\"format_end mceNonEditable\">›</span></span> ',
+     'test word spaces <span class="pc" wce="__t=pc"><span class="format_start mceNonEditable">‹</span>.' +
+     '<span class="format_end mceNonEditable">›</span></span> with punctuation <span class="pc" wce="__t=pc">' +
+     '<span class="format_start mceNonEditable">‹</span>.<span class="format_end mceNonEditable">›</span></span> ',
      '<w>test</w> <w>word</w> <w>spaces</w><pc>.</pc> <w>with</w> <w>punctuation</w><pc>.</pc>'
     ]
   ],
   [ 'test spaces are added to export seg and w',
     ['<w>test</w><w>a</w><w>seg</w><seg type="margin" subtype="pageright"><w>seg</w><w>content</w></seg><w>with</w>' +
      '<w>spaces</w>',
-     'test a seg <span class=\"paratext\" wce=\"__t=paratext&amp;__n=&amp;marginals_text=seg%20content%20' +
-     '&amp;fw_type=isolated&amp;fw_type_other=&amp;paratext_position=pageright&amp;paratext_position_other=\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span>fw<span class=\"format_end mceNonEditable\">›</span>' +
+     'test a seg <span class="paratext" wce="__t=paratext&amp;__n=&amp;marginals_text=seg%20content%20' +
+     '&amp;fw_type=isolated&amp;fw_type_other=&amp;paratext_position=pageright&amp;paratext_position_other=">' +
+     '<span class="format_start mceNonEditable">‹</span>fw<span class="format_end mceNonEditable">›</span>' +
      '</span>with spaces ',
      '<w>test</w> <w>a</w> <w>seg</w><seg type="margin" subtype="pageright"><w>seg</w> <w>content</w></seg> ' +
      '<w>with</w> <w>spaces</w>'
@@ -1258,13 +1265,13 @@ const exportSpaces = new Map([
   [ 'test spaces are added to export app and w combinations',
     ['<w>test</w><w>spaces</w><app><rdg type="orig" hand="firsthand"><w>arround</w></rdg>' +
     '<rdg type="corr" hand="corrector"><w>around</w></rdg></app><w>corrections</w>',
-     'test spaces <span class=\"corr\" wce_orig=\"arround\" wce=\"__t=corr&amp;__n=corrector' +
+     'test spaces <span class="corr" wce_orig="arround" wce="__t=corr&amp;__n=corrector' +
      '&amp;corrector_name_other=&amp;corrector_name=corrector&amp;reading=corr&amp;' +
      'original_firsthand_reading=arround&amp;common_firsthand_partial=&amp;deletion_erased=0&amp;' +
      'deletion_underline=0&amp;deletion_underdot=0&amp;deletion_strikethrough=0&amp;deletion_vertical_line=0' +
      '&amp;deletion_deletion_hooks=0&amp;deletion_transposition_marks=0&amp;deletion_other=0&amp;deletion=null' +
-     '&amp;firsthand_partial=&amp;partial=&amp;corrector_text=around%20&amp;place_corr=\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span>arround<span class=\"format_end mceNonEditable\">›</span>' +
+     '&amp;firsthand_partial=&amp;partial=&amp;corrector_text=around%20&amp;place_corr=">' +
+     '<span class="format_start mceNonEditable">‹</span>arround<span class="format_end mceNonEditable">›</span>' +
      '</span> corrections ',
      '<w>test</w> <w>spaces</w> <app><rdg type="orig" hand="firsthand"><w>arround</w></rdg>' +
      '<rdg type="corr" hand="corrector"><w>around</w></rdg></app> <w>corrections</w>'
@@ -1273,76 +1280,76 @@ const exportSpaces = new Map([
   [ 'test spaces are added to export app and pc combination',
     ['<w>test</w><w>spaces</w><pc>.</pc><app><rdg type="orig" hand="firsthand"><w>arround</w></rdg>' +
      '<rdg type="corr" hand="corrector"><w>around</w></rdg></app><w>corrections</w>',
-     'test spaces <span class=\"pc\" wce=\"__t=pc\"><span class=\"format_start mceNonEditable\">‹</span>.' +
-     '<span class=\"format_end mceNonEditable\">›</span></span> <span class=\"corr\" wce_orig=\"arround\" ' +
-     'wce=\"__t=corr&amp;__n=corrector&amp;corrector_name_other=&amp;corrector_name=corrector&amp;reading=corr' +
+     'test spaces <span class="pc" wce="__t=pc"><span class="format_start mceNonEditable">‹</span>.' +
+     '<span class="format_end mceNonEditable">›</span></span> <span class="corr" wce_orig="arround" ' +
+     'wce="__t=corr&amp;__n=corrector&amp;corrector_name_other=&amp;corrector_name=corrector&amp;reading=corr' +
      '&amp;original_firsthand_reading=arround&amp;common_firsthand_partial=&amp;deletion_erased=0&amp;' +
      'deletion_underline=0&amp;deletion_underdot=0&amp;deletion_strikethrough=0&amp;deletion_vertical_line=0' +
      '&amp;deletion_deletion_hooks=0&amp;deletion_transposition_marks=0&amp;deletion_other=0&amp;deletion=null' +
-     '&amp;firsthand_partial=&amp;partial=&amp;corrector_text=around%20&amp;place_corr=\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span>arround<span class=\"format_end mceNonEditable\">›</span>' +
+     '&amp;firsthand_partial=&amp;partial=&amp;corrector_text=around%20&amp;place_corr=">' +
+     '<span class="format_start mceNonEditable">‹</span>arround<span class="format_end mceNonEditable">›</span>' +
      '</span> corrections ',
      '<w>test</w> <w>spaces</w><pc>.</pc> <app><rdg type="orig" hand="firsthand"><w>arround</w></rdg>' +
      '<rdg type="corr" hand="corrector"><w>around</w></rdg></app> <w>corrections</w>'
     ]
   ],
   [ 'test spaces are added after notes between words',
-    ['<w>test</w><w>note</w><note type="local" xml:id="..--2">my test note</note><w>between</w><w>words</w>',
-     'test note<span class=\"note\" wce=\"__t=note&amp;__n=&amp;note_text=my%20test%20note&amp;' +
-     'note_type=local&amp;newhand=\"><span class=\"format_start mceNonEditable\">‹</span>Note' +
-     '<span class=\"format_end mceNonEditable\">›</span></span> between words ',
-     '<w>test</w> <w>note</w><note type="local" xml:id="..-undefined-2">my test note</note> <w>between</w> <w>words</w>'
+    ['<w>test</w><w>note</w><note type="local">my test note</note><w>between</w><w>words</w>',
+     'test note<span class="note" wce="__t=note&amp;__n=&amp;note_text=my%20test%20note&amp;' +
+     'note_type=local&amp;newhand="><span class="format_start mceNonEditable">‹</span>Note' +
+     '<span class="format_end mceNonEditable">›</span></span> between words ',
+     '<w>test</w> <w>note</w><note type="local">my test note</note> <w>between</w> <w>words</w>'
     ]
   ],
   [ 'test spaces are added after notes before app',
-    ['<w>test</w><w>note</w><note type="local" xml:id="..--2">my test note</note><app>' +
+    ['<w>test</w><w>note</w><note type="local">my test note</note><app>' +
      '<rdg type="orig" hand="firsthand"><w>before</w><w>app</w></rdg><rdg type="corr" hand="corrector"></rdg></app>',
-     'test note<span class=\"note\" wce=\"__t=note&amp;__n=&amp;note_text=my%20test%20note&amp;note_type=local&amp;' +
-     'newhand=\"><span class=\"format_start mceNonEditable\">‹</span>Note<span class=\"format_end mceNonEditable\">›' +
-     '</span></span> <span class=\"corr\" wce_orig=\"before%20app\" wce=\"__t=corr&amp;__n=corrector&amp;' +
+     'test note<span class="note" wce="__t=note&amp;__n=&amp;note_text=my%20test%20note&amp;note_type=local&amp;' +
+     'newhand="><span class="format_start mceNonEditable">‹</span>Note<span class="format_end mceNonEditable">›' +
+     '</span></span> <span class="corr" wce_orig="before%20app" wce="__t=corr&amp;__n=corrector&amp;' +
      'corrector_name_other=&amp;corrector_name=corrector&amp;reading=corr&amp;original_firsthand_reading=' +
      'before%20app&amp;common_firsthand_partial=&amp;deletion_erased=0&amp;deletion_underline=0&amp;' +
      'deletion_underdot=0&amp;deletion_strikethrough=0&amp;deletion_vertical_line=0&amp;deletion_deletion_hooks=0' +
      '&amp;deletion_transposition_marks=0&amp;deletion_other=0&amp;deletion=null&amp;firsthand_partial=&amp;partial=' +
-     '&amp;corrector_text=&amp;blank_correction=on&amp;place_corr=\"><span class=\"format_start mceNonEditable\">‹' +
-     '</span>before app<span class=\"format_end mceNonEditable\">›</span></span>',
-     '<w>test</w> <w>note</w><note type="local" xml:id="..-undefined-2">my test note</note> <app>' +
+     '&amp;corrector_text=&amp;blank_correction=on&amp;place_corr="><span class="format_start mceNonEditable">‹' +
+     '</span>before app<span class="format_end mceNonEditable">›</span></span>',
+     '<w>test</w> <w>note</w><note type="local">my test note</note> <app>' +
      '<rdg type="orig" hand="firsthand"><w>before</w> <w>app</w></rdg><rdg type="corr" hand="corrector"></rdg></app>'
     ]
   ],
   [ 'test spaces are added between verses',
     ['<div type="book" n="Matt"><div type="chapter" n="Matt.1"><ab n="Matt.1.1"><w>test</w><w>spaces</w></ab>' +
      '<ab n="Matt.1.2"><w>between</w><w>verses</w></ab></div></div>',
-     ' <span class=\"book_number mceNonEditable\" wce=\"__t=book_number\" id=\"1\">Matt</span>  ' +
-     '<span class=\"chapter_number mceNonEditable\" wce=\"__t=chapter_number\" id=\"2\">1</span> ' +
-     '<span class=\"verse_number mceNonEditable\" wce=\"__t=verse_number\">1</span> test spaces ' +
-     '<span class=\"verse_number mceNonEditable\" wce=\"__t=verse_number\">2</span> between verses ',
+     ' <span class="book_number mceNonEditable" wce="__t=book_number" id="1">Matt</span>  ' +
+     '<span class="chapter_number mceNonEditable" wce="__t=chapter_number" id="2">1</span> ' +
+     '<span class="verse_number mceNonEditable" wce="__t=verse_number">1</span> test spaces ' +
+     '<span class="verse_number mceNonEditable" wce="__t=verse_number">2</span> between verses ',
      '<div type="book" n="Matt"><div type="chapter" n="Matt.1"><ab n="Matt.1.1"><w>test</w> <w>spaces</w></ab> ' +
      '<ab n="Matt.1.2"><w>between</w> <w>verses</w></ab></div> </div>'
     ]
   ],
   [ 'test spaces are added between word and space',
     ['<w>word</w><w>then</w><w>space</w><space unit="char" extent="5"/><w>and</w><w>more</w><w>words</w>',
-     'word then space <span class=\"spaces\" wce=\"__t=spaces&amp;__n=&amp;sp_unit_other=&amp;sp_unit=char&amp;' +
-     'sp_extent=5\"><span class=\"format_start mceNonEditable\">‹</span>sp' +
-     '<span class=\"format_end mceNonEditable\">›</span></span>and more words ',
+     'word then space <span class="spaces" wce="__t=spaces&amp;__n=&amp;sp_unit_other=&amp;sp_unit=char&amp;' +
+     'sp_extent=5"><span class="format_start mceNonEditable">‹</span>sp' +
+     '<span class="format_end mceNonEditable">›</span></span>and more words ',
      '<w>word</w> <w>then</w> <w>space</w> <space unit="char" extent="5"/><w>and</w> <w>more</w> <w>words</w>'
     ]
   ],
   [ 'test spaces are added between word and gap and word',
     ['<w>word</w><w>then</w><w>gap</w><gap reason="illegible" unit="char" extent="5"/><w>and</w><w>more</w><w>words</w>',
-     'word then gap <span class=\"gap\" wce=\"__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
+     'word then gap <span class="gap" wce="__t=gap&amp;__n=&amp;gap_reason_dummy_lacuna=lacuna&amp;' +
      'gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;' +
      'gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit_other=&amp;' +
-     'unit=char&amp;extent=5\"><span class=\"format_start mceNonEditable\">‹</span>[5]' +
-     '<span class=\"format_end mceNonEditable\">›</span></span> and more words ',
+     'unit=char&amp;extent=5"><span class="format_start mceNonEditable">‹</span>[5]' +
+     '<span class="format_end mceNonEditable">›</span></span> and more words ',
      '<w>word</w> <w>then</w> <w>gap</w> <gap reason="illegible" unit="char" extent="5"/> <w>and</w> <w>more</w> <w>words</w>'
     ]
   ],
   [ 'test space is added after chapter when ending with w',
     ['<div type="book" n="Matt"><div type="chapter" n="Matt.1"><ab n="Matt.1.1"><w>space</w><w>after</w><w>chapter</w>' +
      '</ab></div><div type="chapter" n="Matt.2"><ab n="Matt.2.1"><w>next</w><w>chapter</w></ab></div></div>',
-     ' <span class=\"book_number mceNonEditable\" wce=\"__t=book_number\" id=\"1\">Matt</span>  <span class=\"chapter_number mceNonEditable\" wce=\"__t=chapter_number\" id=\"2\">1</span> <span class=\"verse_number mceNonEditable\" wce=\"__t=verse_number\">1</span> space after chapter  <span class=\"chapter_number mceNonEditable\" wce=\"__t=chapter_number\" id=\"3\">2</span> <span class=\"verse_number mceNonEditable\" wce=\"__t=verse_number\">1</span> next chapter ',
+     ' <span class="book_number mceNonEditable" wce="__t=book_number" id="1">Matt</span>  <span class="chapter_number mceNonEditable" wce="__t=chapter_number" id="2">1</span> <span class="verse_number mceNonEditable" wce="__t=verse_number">1</span> space after chapter  <span class="chapter_number mceNonEditable" wce="__t=chapter_number" id="3">2</span> <span class="verse_number mceNonEditable" wce="__t=verse_number">1</span> next chapter ',
      '<div type="book" n="Matt"><div type="chapter" n="Matt.1"><ab n="Matt.1.1"><w>space</w> <w>after</w> <w>chapter</w>' +
      '</ab></div> <div type="chapter" n="Matt.2"><ab n="Matt.2.1"><w>next</w> <w>chapter</w></ab></div> </div>'
     ]
@@ -1351,7 +1358,7 @@ const exportSpaces = new Map([
     ['<div type="book" n="Matt"><div type="chapter" n="Matt.1"><ab n="Matt.1.1"><w>space</w><w>after</w><w>chapter</w>' +
      '<w>with</w><w>pc</w><pc>.</pc></ab></div><div type="chapter" n="Matt.2"><ab n="Matt.2.1"><w>next</w>' +
      '<w>chapter</w></ab></div></div>',
-     ' <span class=\"book_number mceNonEditable\" wce=\"__t=book_number\" id=\"1\">Matt</span>  <span class=\"chapter_number mceNonEditable\" wce=\"__t=chapter_number\" id=\"2\">1</span> <span class=\"verse_number mceNonEditable\" wce=\"__t=verse_number\">1</span> space after chapter with pc <span class=\"pc\" wce=\"__t=pc\"><span class=\"format_start mceNonEditable\">‹</span>.<span class=\"format_end mceNonEditable\">›</span></span>  <span class=\"chapter_number mceNonEditable\" wce=\"__t=chapter_number\" id=\"3\">2</span> <span class=\"verse_number mceNonEditable\" wce=\"__t=verse_number\">1</span> next chapter ',
+     ' <span class="book_number mceNonEditable" wce="__t=book_number" id="1">Matt</span>  <span class="chapter_number mceNonEditable" wce="__t=chapter_number" id="2">1</span> <span class="verse_number mceNonEditable" wce="__t=verse_number">1</span> space after chapter with pc <span class="pc" wce="__t=pc"><span class="format_start mceNonEditable">‹</span>.<span class="format_end mceNonEditable">›</span></span>  <span class="chapter_number mceNonEditable" wce="__t=chapter_number" id="3">2</span> <span class="verse_number mceNonEditable" wce="__t=verse_number">1</span> next chapter ',
      '<div type="book" n="Matt"><div type="chapter" n="Matt.1"><ab n="Matt.1.1"><w>space</w> <w>after</w> ' +
      '<w>chapter</w> <w>with</w> <w>pc</w><pc>.</pc></ab></div> <div type="chapter" n="Matt.2"><ab n="Matt.2.1">' +
      '<w>next</w> <w>chapter</w></ab></div> </div>'
@@ -1384,18 +1391,18 @@ const exportLayout = new Map([
   [ 'test input without linebreaks in XML get them added on export',
     ['<pb n="1r" type="folio" xml:id="P1r-"/><cb n="P1rC1-"/><lb n="P1rC1L-"/><w>test</w><w>that</w><w>line</w>' +
      '<w>breaks</w><lb n="P1rC1L-"/><w>are</w><w>added</w><w>in</w><w>XML</w>',
-     '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-     'break_type=pb&amp;number=1&amp;rv=r&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1r<span class=\"format_end mceNonEditable\">›</span>' +
-     '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-     'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-     '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=lb&amp;' +
-     'number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-     '</span> test that line breaks <span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;' +
-     'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-     '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+     '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+     'break_type=pb&amp;number=1&amp;rv=r&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+     '<span class="format_start mceNonEditable">‹</span><br/>PB 1r<span class="format_end mceNonEditable">›</span>' +
+     '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+     'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+     '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+     '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=lb&amp;' +
+     'number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+     '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+     '</span> test that line breaks <span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;' +
+     'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+     '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
      '</span> are added in XML ',
      '\n<pb n="1r" type="folio" xml:id="P1r-undefined"/>\n<cb n="P1rC1-undefined"/>\n<lb n="P1rC1L-undefined"/><w>test</w><w>that</w><w>line</w>' +
      '<w>breaks</w>\n<lb n="P1rC1L-undefined"/><w>are</w><w>added</w><w>in</w><w>XML</w>'
@@ -1404,18 +1411,18 @@ const exportLayout = new Map([
   [ 'test input with linebreaks in XML still has them on export',
     ['\n<pb n="1r" type="folio" xml:id="P1r-"/>\n<cb n="P1rC1-"/>\n<lb n="P1rC1L-"/><w>test</w><w>that</w><w>line</w>' +
       '<w>breaks</w>\n<lb n="P1rC1L-"/><w>are</w><w>added</w><w>in</w><w>XML</w>',
-      '<span class=\"mceNonEditable brea\" id=\"pb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=pb&amp;number=1&amp;rv=r&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>PB 1r<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"cb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>CB 1<span class=\"format_end mceNonEditable\">›</span>' +
-      '</span><span class=\"mceNonEditable brea\" id=\"lb_3_MATH.RAND\" wce=\"__t=brea&amp;__n=&amp;break_type=lb&amp;' +
-      'number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
-      '</span> test that line breaks <span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;' +
-      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no\">' +
-      '<span class=\"format_start mceNonEditable\">‹</span><br/>↵ <span class=\"format_end mceNonEditable\">›</span>' +
+      '<span class="mceNonEditable brea" id="pb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=pb&amp;number=1&amp;rv=r&amp;fibre_type=&amp;facs=&amp;lb_alignment=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>PB 1r<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="cb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=cb&amp;number=1&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>CB 1<span class="format_end mceNonEditable">›</span>' +
+      '</span><span class="mceNonEditable brea" id="lb_3_MATH.RAND" wce="__t=brea&amp;__n=&amp;break_type=lb&amp;' +
+      'number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
+      '</span> test that line breaks <span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;' +
+      'break_type=lb&amp;number=&amp;lb_alignment=&amp;rv=&amp;fibre_type=&amp;facs=&amp;hasBreak=no">' +
+      '<span class="format_start mceNonEditable">‹</span><br/>↵ <span class="format_end mceNonEditable">›</span>' +
       '</span> are added in XML ',
       '\n<pb n="1r" type="folio" xml:id="P1r-undefined"/>\n<cb n="P1rC1-undefined"/>\n<lb n="P1rC1L-undefined"/><w>test</w><w>that</w><w>line</w>' +
       '<w>breaks</w>\n<lb n="P1rC1L-undefined"/><w>are</w><w>added</w><w>in</w><w>XML</w>'

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -1773,10 +1773,6 @@ function getTeiByHtml(inputString, clientOptions) {
 
 	var isSeg = false;
 
-	// commented out by Cat because notes don't need xml ids
-	// var note = 1;
-	// var idSet = new Set();
-
 	/*
 	 * Main Method <br /> return String of TEI-Format XML
 	 *
@@ -3291,22 +3287,6 @@ function getTeiByHtml(inputString, clientOptions) {
 				$note.setAttribute('type', note_type_value);
 			}
 		}
-
-		var $lastNode = $teiParent.lastChild;
-		// if ($lastNode) {
-		// 	note++;
-		// } else // this is important for notes being inserted directly after the verse number
-		// 	note = 1;
-		// commented out by Cat because notes don't need an XML id
-		// var xml_id = g_bookNumber + '.' + g_chapterNumber + '.' + g_verseNumber + '-' + g_witValue + '-' + note;
-		// var temp='';
-		// var i=65;
-		// while (idSet.has(xml_id + temp)) {
-		// 	temp = String.fromCharCode(i).toLowerCase();
-		// 	i++;
-		// }
-		// $note.setAttribute('xml:id', xml_id + temp);
-		// idSet.add(xml_id + temp);
 
 		// add <handShift/> if necessary
 		if (note_type_value === "changeOfHand") {

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -1481,7 +1481,8 @@ function getHtmlByTei(inputString, clientOptions) {
 					wceAttr += '&newHand=';
 			} else {
 				var mapping = {
-					'xml:id' : null,
+					// commented out by Cat because notes don't need xml ids
+					// 'xml:id' : null,
 					'type' : {
 						'0' : '@editorial@local@canonRef',
 						'1' : '&note_type=',
@@ -1775,7 +1776,8 @@ function getTeiByHtml(inputString, clientOptions) {
 	var isSeg = false;
 	var note = 1;
 
-	var idSet = new Set();
+	// commented out by Cat because notes don't need xml ids
+	// var idSet = new Set();
 
 	/*
 	 * Main Method <br /> return String of TEI-Format XML
@@ -3297,15 +3299,16 @@ function getTeiByHtml(inputString, clientOptions) {
 			note++;
 		} else // this is important for notes being inserted directly after the verse number
 			note = 1;
-		var xml_id = g_bookNumber + '.' + g_chapterNumber + '.' + g_verseNumber + '-' + g_witValue + '-' + note;
-		var temp='';
-		var i=65;
-		while (idSet.has(xml_id + temp)) {
-			temp = String.fromCharCode(i).toLowerCase();
-			i++;
-		}
-		$note.setAttribute('xml:id', xml_id + temp);
-		idSet.add(xml_id + temp);
+		// commented out by Cat because notes don't need an XML id
+		// var xml_id = g_bookNumber + '.' + g_chapterNumber + '.' + g_verseNumber + '-' + g_witValue + '-' + note;
+		// var temp='';
+		// var i=65;
+		// while (idSet.has(xml_id + temp)) {
+		// 	temp = String.fromCharCode(i).toLowerCase();
+		// 	i++;
+		// }
+		// $note.setAttribute('xml:id', xml_id + temp);
+		// idSet.add(xml_id + temp);
 
 		// add <handShift/> if necessary
 		if (note_type_value === "changeOfHand") {

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -1397,7 +1397,7 @@ function getHtmlByTei(inputString, clientOptions) {
 	 * <note>
 	 */
 	var Tei2Html_note = function($htmlParent, $teiNode) {
-		// <note type="$ note_type" n="$newHand" xml:id="_TODO_" > $note_text </note>
+		// <note type="$ note_type" n="$newHand"> $note_text </note>
 
 		var $newNode = $newDoc.createElement('span');
 
@@ -1481,8 +1481,6 @@ function getHtmlByTei(inputString, clientOptions) {
 					wceAttr += '&newHand=';
 			} else {
 				var mapping = {
-					// commented out by Cat because notes don't need xml ids
-					// 'xml:id' : null,
 					'type' : {
 						'0' : '@editorial@local@canonRef',
 						'1' : '&note_type=',
@@ -1774,9 +1772,9 @@ function getTeiByHtml(inputString, clientOptions) {
 	var w_end_s='}@@@}';
 
 	var isSeg = false;
-	var note = 1;
 
 	// commented out by Cat because notes don't need xml ids
+	// var note = 1;
 	// var idSet = new Set();
 
 	/*
@@ -3295,10 +3293,10 @@ function getTeiByHtml(inputString, clientOptions) {
 		}
 
 		var $lastNode = $teiParent.lastChild;
-		if ($lastNode) {
-			note++;
-		} else // this is important for notes being inserted directly after the verse number
-			note = 1;
+		// if ($lastNode) {
+		// 	note++;
+		// } else // this is important for notes being inserted directly after the verse number
+		// 	note = 1;
 		// commented out by Cat because notes don't need an XML id
 		// var xml_id = g_bookNumber + '.' + g_chapterNumber + '.' + g_verseNumber + '-' + g_witValue + '-' + note;
 		// var temp='';


### PR DESCRIPTION
Our preferred solution of removing the XML ids from notes didn't break anything internally in the editor, in fact only half of it was ever written. I have removed all of the code that did that, updated all existing tests to reflect the change and added a test to ensure that if XML has xml:ids on notes when it goes into the OTE they are removed when exported. 

Closes #103 