### PR TITLE
Page gap fix

### DIFF
--- a/__tests__/default_functional_tests/gap_menu.tests.js
+++ b/__tests__/default_functional_tests/gap_menu.tests.js
@@ -19,6 +19,7 @@ beforeAll(async () => {
   browser = await puppeteer.launch({
     // for local testing
     // headless: false,
+    // devtools: true,
     // slowMo: 80,
     // args: ['--window-size=1920,1080', '--disable-web-security']
 
@@ -37,7 +38,6 @@ beforeEach(async () => {
   let frameHandle;
   jest.setTimeout(5000000);
   page = await browser.newPage();
-  // await page.goto(`file:${path.join(__dirname, '..', 'wce-ote', 'index.html')}`);
   await page.goto(`file:${path.join(__dirname, '../test_index_page.html')}`);
   await page.evaluate(`setWceEditor('wce_editor', {})`);
   page.waitForSelector("#wce_editor_ifr");
@@ -571,7 +571,7 @@ describe('testing gap menu', () => {
     await page.waitForSelector('div[id="mceu_40"]', { hidden: true });
 
     var htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('this <span class=\"gap\" wce_orig=\"\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=char&amp;unit_other=&amp;extent=10&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=\"><span class=\"format_start mceNonEditable\">‹</span>[10]<span class=\"format_end mceNonEditable\">›</span></span> continues');
+    expect(htmlData).toBe('this <span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=char&amp;unit_other=&amp;extent=10&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span>[10]<span class="format_end mceNonEditable">›</span></span> continues');
     var xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>this</w><gap reason="illegible" unit="char" extent="10"/><w>continues</w>' + xmlTail);
 
@@ -731,7 +731,7 @@ describe('testing gap menu', () => {
     await page.waitForSelector('div[id="mceu_40"]', { hidden: true });
 
     const htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('this <span class=\"gap\" wce_orig=\"\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=unspecified&amp;unit=&amp;unit_other=&amp;extent=&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=\"><span class=\"format_start mceNonEditable\">‹</span>[...]<span class=\"format_end mceNonEditable\">›</span></span> continues');
+    expect(htmlData).toBe('this <span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=unspecified&amp;unit=&amp;unit_other=&amp;extent=&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span>[...]<span class="format_end mceNonEditable">›</span></span> continues');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>this</w><gap reason="unspecified"/><w>continues</w>' + xmlTail);
   }, 200000);
@@ -753,7 +753,7 @@ describe('testing gap menu', () => {
     await page.waitForSelector('div[id="mceu_40"]', { hidden: true });
 
     const htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('wo<span class=\"gap\" wce_orig=\"\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=char&amp;unit_other=&amp;extent=2&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=\"><span class=\"format_start mceNonEditable\">‹</span>[2]<span class=\"format_end mceNonEditable\">›</span></span>');
+    expect(htmlData).toBe('wo<span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=char&amp;unit_other=&amp;extent=2&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span>[2]<span class="format_end mceNonEditable">›</span></span>');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>wo<gap reason="illegible" unit="char" extent="2"/></w>' + xmlTail);
   }, 200000);
@@ -773,7 +773,7 @@ describe('testing gap menu', () => {
     await page.waitForSelector('div[id="mceu_40"]', { hidden: true });
 
     const htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('wo<span class=\"gap\" wce_orig=\"\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=&amp;unit_other=&amp;extent=&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=\"><span class=\"format_start mceNonEditable\">‹</span>[...]<span class=\"format_end mceNonEditable\">›</span></span>');
+    expect(htmlData).toBe('wo<span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=&amp;unit_other=&amp;extent=&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span>[...]<span class="format_end mceNonEditable">›</span></span>');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>wo<gap reason="illegible"/></w>' + xmlTail);
   }, 200000);
@@ -798,7 +798,7 @@ describe('testing gap menu', () => {
     const idRegex = /id="gap_(\d)_\d+"/g;
     const htmlData = await page.evaluate(`getData()`);
     const modifiedHtml = htmlData.replace(idRegex, 'id="gap_$1_MATH.RAND"');
-    expect(modifiedHtml).toBe('missing line<span class=\"gap\" wce_orig=\"\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=line&amp;unit_other=&amp;extent=part&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=\" id=\"gap_2_MATH.RAND\"><span class=\"format_start mceNonEditable\">‹</span>[...]<span class=\"format_end mceNonEditable\">›</span></span>');
+    expect(modifiedHtml).toBe('missing line<span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=line&amp;unit_other=&amp;extent=part&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=" id="gap_2_MATH.RAND"><span class="format_start mceNonEditable">‹</span>[...]<span class="format_end mceNonEditable">›</span></span>');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>missing</w><w>line<gap reason="illegible" unit="line" extent="part"/></w>' + xmlTail);
   }, 200000);
@@ -821,7 +821,7 @@ describe('testing gap menu', () => {
     const idRegex = /id="gap_(\d)_\d+"/g;
     const htmlData = await page.evaluate(`getData()`);
     const modifiedHtml = htmlData.replace(idRegex, 'id="gap_$1_MATH.RAND"');
-    expect(modifiedHtml).toBe('missing line<span class=\"gap\" wce_orig=\"\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=line&amp;unit_other=&amp;extent=unspecified&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=\" id=\"gap_2_MATH.RAND\"><span class=\"format_start mceNonEditable\">‹</span>[...]<span class=\"format_end mceNonEditable\">›</span></span>');
+    expect(modifiedHtml).toBe('missing line<span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=line&amp;unit_other=&amp;extent=unspecified&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=" id="gap_2_MATH.RAND"><span class="format_start mceNonEditable">‹</span>[...]<span class="format_end mceNonEditable">›</span></span>');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>missing</w><w>line<gap reason="illegible" unit="line" extent="unspecified"/></w>' + xmlTail);
   }, 200000);
@@ -846,7 +846,7 @@ describe('testing gap menu', () => {
     await menuFrame.click('input#insert');
     await page.waitForSelector('div[id="mceu_40"]', { hidden: true });
     const htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('missing <span class=\"gap\" wce_orig=\"\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=quire&amp;unit_other=&amp;extent=1&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=\"><span class=\"format_start mceNonEditable\">‹</span><br />QB<br />[...]<span class=\"format_end mceNonEditable\">›</span></span> quire');
+    expect(htmlData).toBe('missing <span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=quire&amp;unit_other=&amp;extent=1&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span><br />QB<br />[...]<span class="format_end mceNonEditable">›</span></span> quire');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>missing</w><gap reason="lacuna" unit="quire" extent="1"/><w>quire</w>' + xmlTail);
 
@@ -915,10 +915,20 @@ describe('testing gap menu', () => {
     const idRegex = /id="(\D+)_(\d)_\d+"/g;
     const htmlData = await page.evaluate(`getData()`);
     const modifiedHtml = htmlData.replace(idRegex, 'id="$1_$2_MATH.RAND"');
-    expect(modifiedHtml).toBe('missing <span class=\"gap\" wce_orig=\"\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=page&amp;unit_other=&amp;extent=2&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=\" id=\"gap_4_MATH.RAND\"><span class=\"format_start mceNonEditable\">‹</span><br />PB<br />[...]<br />PB<br />[...]<span class=\"format_end mceNonEditable\">›</span></span><span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;break_type=pb&amp;number=1&amp;rv=r&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=\" id=\"pb_4_MATH.RAND\"><span class=\"format_start mceNonEditable\">‹</span><br />PB 1r<span class=\"format_end mceNonEditable\">›</span></span><span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;break_type=cb&amp;number=1&amp;rv=&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=\" id=\"cb_4_MATH.RAND\"><span class=\"format_start mceNonEditable\">‹</span><br />CB 1<span class=\"format_end mceNonEditable\">›</span></span><span class=\"mceNonEditable brea\" wce=\"__t=brea&amp;__n=&amp;hasBreak=no&amp;break_type=lb&amp;number=&amp;rv=&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=\" id=\"lb_4_MATH.RAND\"><span class=\"format_start mceNonEditable\">‹</span><br />↵<span class=\"format_end mceNonEditable\">›</span></span>  pages');
+    expect(modifiedHtml).toBe('missing <span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=page&amp;unit_other=&amp;extent=2&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=" id="gap_4_MATH.RAND"><span class="format_start mceNonEditable">‹</span><br />PB<br />[...]<br />PB<br />[...] <span class="format_end mceNonEditable">›</span></span> pages');
     const xmlData = await page.evaluate(`getTEI()`);
-    // NB when created in the editor the XML is different compared to this test starting from XML input (page, col and line breaks added here for last page)
-    expect(xmlData).toBe(xmlHead + '<w>missing</w><gap reason="lacuna" unit="page" extent="2"/><pb n="1r" type="folio" xml:id="P1r-"/><cb n="P1rC1-"/><lb n="P1rC1L-"/><w>pages</w>' + xmlTail);
+    expect(xmlData).toBe(xmlHead + '<w>missing</w><gap reason="lacuna" unit="page" extent="2"/><w>pages</w>' + xmlTail);
+  
+    // check we can add a page break after the gap (the OTE used to add this as part of the gap but it caused more 
+    // problems than it solved so it was changed but we do need to be able to add the next page break from the line
+    // that the gap ends on)
+    await page.click('button#mceu_10-open');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    const menuFrameHandle2 = await page.$('div[id="mceu_42"] > div > div > iframe');
+    const menuFrame2 = await menuFrameHandle2.contentFrame();
+    await menuFrame2.select('select[id="break_type"]', 'pb');
+    await menuFrame2.click('input#insert');
 
     // check editing
     await page.keyboard.press('ArrowUp');
@@ -936,25 +946,22 @@ describe('testing gap menu', () => {
     await page.keyboard.press('ArrowRight');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
-    const menuFrameHandle2 = await page.$('div[id="mceu_41"] > div > div > iframe');
-    const menuFrame2 = await menuFrameHandle2.contentFrame();
+    const menuFrameHandle3 = await page.$('div[id="mceu_43"] > div > div > iframe');
+    const menuFrame3 = await menuFrameHandle3.contentFrame();
 
-    expect(await menuFrame2.$eval('#unit', el => el.value)).toBe('page');
-    expect(await menuFrame2.$eval('#unit', el => el.disabled)).toBe(false);
-    expect(await menuFrame2.$eval('input#extent', el => el.value)).toBe('2');
-    expect(await menuFrame2.$eval('#gap_reason_dummy_lacuna', el => el.checked)).toBe(true);
-    expect(await menuFrame2.$eval('#gap_reason', el => el.value)).toBe('lacuna');
+    expect(await menuFrame3.$eval('#unit', el => el.value)).toBe('page');
+    expect(await menuFrame3.$eval('#unit', el => el.disabled)).toBe(false);
+    expect(await menuFrame3.$eval('input#extent', el => el.value)).toBe('2');
+    expect(await menuFrame3.$eval('#gap_reason_dummy_lacuna', el => el.checked)).toBe(true);
+    expect(await menuFrame3.$eval('#gap_reason', el => el.value)).toBe('lacuna');
 
-    await menuFrame2.click('input#insert');
+    await menuFrame3.click('input#insert');
     await page.waitForSelector('div[id="mceu_41"]', { hidden: true });
 
     const xmlData2 = await page.evaluate(`getTEI()`);
-    // TODO: change behaviour so pages are not renumbered on edit
-    // NB: this test current behaviour but not the desired bahviour. the page numbers are changed on edit (No idea why)
-    expect(xmlData2).toBe(xmlHead + '<w>missing</w><gap reason="lacuna" unit="page" extent="2"/><pb n="2v" type="folio" xml:id="P2v-"/><cb n="P2vC1-"/><lb n="P2vC1L-"/><w>pages</w>' + xmlTail);
+    expect(xmlData2).toBe(xmlHead + '<w>missing</w><gap reason="lacuna" unit="page" extent="2"/><pb n="1r" type="folio" xml:id="P1r-"/><cb n="P1rC1-"/><lb n="P1rC1L-"/><w>pages</w>' + xmlTail);
 
     // check deleting
-    await page.keyboard.press('ArrowUp');
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('ArrowUp');
 
@@ -971,7 +978,7 @@ describe('testing gap menu', () => {
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
     const xmlData3 = await page.evaluate(`getTEI()`);
-    expect(xmlData3).toBe(xmlHead + '<w>missing</w><w>pages</w>' + xmlTail);
+    expect(xmlData3).toBe(xmlHead + '<w>missing</w><pb n="1r" type="folio" xml:id="P1r-"/><cb n="P1rC1-"/><lb n="P1rC1L-"/><w>pages</w>' + xmlTail);
 
   }, 200000);
 
@@ -985,7 +992,7 @@ describe('testing gap menu', () => {
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
     const htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('the end of the witness <span class=\"witnessend\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;gap_reason=witnessEnd&amp;unit=&amp;unit_other=&amp;extent=&amp;supplied_source=na28&amp;supplied_source_other=&amp;insert=Insert&amp;cancel=Cancel\"><span class=\"format_start mceNonEditable\">‹</span>Witness End<span class=\"format_end mceNonEditable\">›</span></span>');
+    expect(htmlData).toBe('the end of the witness <span class="witnessend" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;gap_reason=witnessEnd&amp;unit=&amp;unit_other=&amp;extent=&amp;supplied_source=na28&amp;supplied_source_other=&amp;insert=Insert&amp;cancel=Cancel"><span class="format_start mceNonEditable">‹</span>Witness End<span class="format_end mceNonEditable">›</span></span>');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>the</w><w>end</w><w>of</w><w>the</w><w>witness</w><gap reason="witnessEnd"/>' + xmlTail);
   }, 200000);
@@ -1013,7 +1020,7 @@ describe('testing gap menu', () => {
     await menuFrame.click('input#insert');
 
     const htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('a <span class=\"gap\" wce_orig=\"supplied\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=&amp;unit_other=&amp;extent=&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;mark_as_supplied=supplied&amp;supplied_source=na28&amp;supplied_source_other=\"><span class=\"format_start mceNonEditable\">‹</span>[supplied]<span class=\"format_end mceNonEditable\">›</span></span> word');
+    expect(htmlData).toBe('a <span class="gap" wce_orig="supplied" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=&amp;unit_other=&amp;extent=&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;mark_as_supplied=supplied&amp;supplied_source=na28&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span>[supplied]<span class="format_end mceNonEditable">›</span></span> word');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>a</w><w><supplied source="na28" reason="illegible">supplied</supplied></w><w>word</w>' + xmlTail);
   }, 200000);
@@ -1042,7 +1049,7 @@ describe('testing gap menu', () => {
     await menuFrame.click('input#insert');
 
     const htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('a <span class=\"gap\" wce_orig=\"supplied%20wo\" wce=\"__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=&amp;unit_other=&amp;extent=&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;mark_as_supplied=supplied&amp;supplied_source=none&amp;supplied_source_other=\"><span class=\"format_start mceNonEditable\">‹</span>[supplied wo]<span class=\"format_end mceNonEditable\">›</span></span>rd');
+    expect(htmlData).toBe('a <span class="gap" wce_orig="supplied%20wo" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=illegible&amp;unit=&amp;unit_other=&amp;extent=&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;mark_as_supplied=supplied&amp;supplied_source=none&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span>[supplied wo]<span class="format_end mceNonEditable">›</span></span>rd');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>a</w><w><supplied reason="illegible">supplied</supplied></w><w><supplied reason="illegible">wo</supplied>rd</w>' + xmlTail);
   }, 200000);

--- a/__tests__/default_functional_tests/gap_menu.tests.js
+++ b/__tests__/default_functional_tests/gap_menu.tests.js
@@ -846,7 +846,7 @@ describe('testing gap menu', () => {
     await menuFrame.click('input#insert');
     await page.waitForSelector('div[id="mceu_40"]', { hidden: true });
     const htmlData = await page.evaluate(`getData()`);
-    expect(htmlData).toBe('missing <span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=quire&amp;unit_other=&amp;extent=1&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span><br />QB<br />[...]<span class="format_end mceNonEditable">›</span></span> quire');
+    expect(htmlData).toBe('missing <span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=quire&amp;unit_other=&amp;extent=1&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other="><span class="format_start mceNonEditable">‹</span><br />QB<br />[...]<span class="format_end mceNonEditable">›</span></span>​ quire');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>missing</w><gap reason="lacuna" unit="quire" extent="1"/><w>quire</w>' + xmlTail);
 
@@ -915,7 +915,7 @@ describe('testing gap menu', () => {
     const idRegex = /id="(\D+)_(\d)_\d+"/g;
     const htmlData = await page.evaluate(`getData()`);
     const modifiedHtml = htmlData.replace(idRegex, 'id="$1_$2_MATH.RAND"');
-    expect(modifiedHtml).toBe('missing <span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=page&amp;unit_other=&amp;extent=2&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=" id="gap_4_MATH.RAND"><span class="format_start mceNonEditable">‹</span><br />PB<br />[...]<br />PB<br />[...] <span class="format_end mceNonEditable">›</span></span> pages');
+    expect(modifiedHtml).toBe('missing <span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=page&amp;unit_other=&amp;extent=2&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=" id="gap_4_MATH.RAND"><span class="format_start mceNonEditable">‹</span><br />PB<br />[...]<br />PB<br />[...]<span class="format_end mceNonEditable">›</span></span>​ pages');
     const xmlData = await page.evaluate(`getTEI()`);
     expect(xmlData).toBe(xmlHead + '<w>missing</w><gap reason="lacuna" unit="page" extent="2"/><w>pages</w>' + xmlTail);
   
@@ -981,6 +981,51 @@ describe('testing gap menu', () => {
     expect(xmlData3).toBe(xmlHead + '<w>missing</w><pb n="1r" type="folio" xml:id="P1r-"/><cb n="P1rC1-"/><lb n="P1rC1L-"/><w>pages</w>' + xmlTail);
 
   }, 200000);
+
+  test('page break can be added straight after a page gap', async () => {
+
+    // open D menu
+    await page.click('button#mceu_12-open');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('Enter');
+    const menuFrameHandle = await page.$('div[id="mceu_40"] > div > div > iframe');
+    const menuFrame = await menuFrameHandle.contentFrame();
+    await menuFrame.select('select[id="unit"]', 'page');
+    await menuFrame.click('input#gap_reason_dummy_lacuna');
+    await menuFrame.type('input#extent', '2');
+    await menuFrame.click('input#insert');
+    const idRegex = /id="(\D+)_(\d)_\d+"/g;
+    const htmlData = await page.evaluate(`getData()`);
+    const modifiedHtml = htmlData.replace(idRegex, 'id="$1_$2_MATH.RAND"');
+    expect(modifiedHtml).toBe('<span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=page&amp;unit_other=&amp;extent=2&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=" id="gap_4_MATH.RAND"><span class="format_start mceNonEditable">‹</span><br />PB<br />[...]<br />PB<br />[...]<span class="format_end mceNonEditable">›</span></span>​');
+    const xmlData = await page.evaluate(`getTEI()`);
+    expect(xmlData).toBe(xmlHead + '<gap reason="lacuna" unit="page" extent="2"/>' + xmlTail);
+
+    // navigate away and back again to check break menu still activated
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+
+    // open B menu
+    await page.click('button#mceu_10-open');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    const menuFrameHandle2 = await page.$('div[id="mceu_42"] > div > div > iframe');
+    const menuFrame2 = await menuFrameHandle2.contentFrame();
+    await menuFrame2.select('select[id="break_type"]', 'pb');
+    await menuFrame2.click('input#insert');
+    await page.waitForSelector('div[id="mceu_42"]', { hidden: true });
+
+    const htmlData2 = await page.evaluate(`getData()`);
+    const modifiedHtml2 = htmlData2.replace(idRegex, 'id="$1_$2_MATH.RAND"');
+    expect(modifiedHtml2).toBe('<span class="gap" wce_orig="" wce="__t=gap&amp;__n=&amp;original_gap_text=&amp;help=Help&amp;gap_reason_dummy_lacuna=lacuna&amp;gap_reason_dummy_illegible=illegible&amp;gap_reason_dummy_unspecified=unspecified&amp;gap_reason_dummy_inferredPage=inferredPage&amp;gap_reason=lacuna&amp;unit=page&amp;unit_other=&amp;extent=2&amp;extent_unspecified=Extent%3DUnspecified&amp;extent_part=Extent%3DPart&amp;supplied_source=na28&amp;supplied_source_other=" id="gap_4_MATH.RAND"><span class="format_start mceNonEditable">‹</span><br />PB<br />[...]<br />PB<br />[...]<span class="format_end mceNonEditable">›</span></span>​<span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;hasBreak=no&amp;help=Help&amp;break_type=pb&amp;number=1&amp;rv=r&amp;fibre_type=&amp;lb_alignment=&amp;facs=" id="pb_3_MATH.RAND"><span class="format_start mceNonEditable">‹</span><br />PB 1r<span class="format_end mceNonEditable">›</span></span><span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;break_type=cb&amp;number=1&amp;rv=&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=" id="cb_3_MATH.RAND"><span class="format_start mceNonEditable">‹</span><br />CB 1<span class="format_end mceNonEditable">›</span></span><span class="mceNonEditable brea" wce="__t=brea&amp;__n=&amp;hasBreak=no&amp;break_type=lb&amp;number=&amp;rv=&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=" id="lb_3_MATH.RAND"><span class="format_start mceNonEditable">‹</span><br />↵<span class="format_end mceNonEditable">›</span></span>');
+    const xmlData2 = await page.evaluate(`getTEI()`);
+    expect(xmlData2).toBe(xmlHead + '<gap reason="lacuna" unit="page" extent="2"/><pb n="1r" type="folio" xml:id="P1r-"/><cb n="P1rC1-"/><lb n="P1rC1L-"/>' + xmlTail);
+
+  }, 200000); 
 
   test('gap witness end', async () => {
     await frame.type('body#tinymce', 'the end of the witness ');

--- a/wce-ote/plugin/js/wce.js
+++ b/wce-ote/plugin/js/wce.js
@@ -215,7 +215,6 @@ function writeWceNodeInfo(val) {
 						for (var i = 0; i < gap_extent; i++) {
 							gap_text += '<br/>PB<br/>[...]';
 						}
-						gap_text += ' ';
 						gap_id = '_4_' + wceUtils.getRandomID(ed, '');
 						wceUtils.addToCounter(ed, 'pb', gap_extent);
 					} else if (gap_unit == "quire") {
@@ -232,6 +231,10 @@ function writeWceNodeInfo(val) {
 				}
 
 				selected_content = gap_text;
+				if (gap_unit == 'page' || gap_unit == 'quire') {
+					// then we need a space at the end so that the next page break can be added
+					new_content = '<span wce="' + newWceAttr + '"' + wceID + wceClass + original_text + '>' + startFormatHtml + selected_content + endFormatHtml + '</span>&#8203;';
+				}
 				break;
 
 			case 'brea':

--- a/wce-ote/plugin/js/wce.js
+++ b/wce-ote/plugin/js/wce.js
@@ -375,11 +375,6 @@ function writeWceNodeInfo(val) {
 					ed.selection.setContent(wceUtils.getBreakHtml(ed, 'lb', null, null, null, gap_id));
 				}
 			} 
-			// else if (gap_unit == "page") {
-			// 	wceUtils.updateBreakCounter(ed, 'pb', 0);
-			// 	ed.selection.setContent(wceUtils.getBreakHtml(ed, 'pb', null, null, null, gap_id));
-			// }
-
 		}
 
 		if (wceUtils) {

--- a/wce-ote/plugin/js/wce.js
+++ b/wce-ote/plugin/js/wce.js
@@ -215,6 +215,7 @@ function writeWceNodeInfo(val) {
 						for (var i = 0; i < gap_extent; i++) {
 							gap_text += '<br/>PB<br/>[...]';
 						}
+						gap_text += ' ';
 						gap_id = '_4_' + wceUtils.getRandomID(ed, '');
 						wceUtils.addToCounter(ed, 'pb', gap_extent);
 					} else if (gap_unit == "quire") {
@@ -373,10 +374,11 @@ function writeWceNodeInfo(val) {
 					wceUtils.updateBreakCounter(ed, 'lb', 0);
 					ed.selection.setContent(wceUtils.getBreakHtml(ed, 'lb', null, null, null, gap_id));
 				}
-			} else if (gap_unit == "page") {
-				wceUtils.updateBreakCounter(ed, 'pb', 0);
-				ed.selection.setContent(wceUtils.getBreakHtml(ed, 'pb', null, null, null, gap_id));
-			}
+			} 
+			// else if (gap_unit == "page") {
+			// 	wceUtils.updateBreakCounter(ed, 'pb', 0);
+			// 	ed.selection.setContent(wceUtils.getBreakHtml(ed, 'pb', null, null, null, gap_id));
+			// }
 
 		}
 

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -1782,6 +1782,7 @@ function getTeiByHtml(inputString, clientOptions) {
 	 *
 	 */
 	var getTeiString = function() {
+		inputString = inputString.replace(/[\u200B]/g, ''); // take out the special character used before breaks to sort out menu options (also at end of multi page gaps)
 		inputString = inputString.replace(/>\s+</g, '> <');//after initHtmlContent get <w before="1" after="1" />
 		inputString = '<TEI>' + inputString + '</TEI>';
 


### PR DESCRIPTION
This shouldn't be relevant to NTVMR transcribers because it relates to gaps of one or more whole pages. Previously the page, column and line breaks for the page following the gap were automatically added with a guestimated page number (sometimes NaN if a page number couldn't be properly generated). Other than the page number issue there were a few other problems such as the breaks being deleted if the gap was deleted and also the auto generated page number being recalculated and changed every time the gap was edited. I have added a space after the gap to ensure that a page break can be manually added. We think this is a better solution for ITSEE and is probably irrelevant for your users.

closes #77 
closes #90 