### PR TITLE
 update to node 16

### DIFF
--- a/.github/workflows/ci-jest-tests.yml
+++ b/.github/workflows/ci-jest-tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: "12"
+          node-version: "16"
 
       # Speed up subsequent runs with caching
       - name: Cache node modules


### PR DESCRIPTION
12 is deprecated and github won't run it anymore for our CI tests