### PR TITLE
Addition to Marginalia form so references can be added to chapTitle and lectTitle

### DIFF
--- a/.github/workflows/ci-jest-tests.yml
+++ b/.github/workflows/ci-jest-tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: "12"
+          node-version: "16"
 
       # Speed up subsequent runs with caching
       - name: Cache node modules

--- a/__tests__/nondefault_functional_tests/marginalia_nd_menu.tests.js
+++ b/__tests__/nondefault_functional_tests/marginalia_nd_menu.tests.js
@@ -70,7 +70,7 @@ describe('test a optional defaults for marginalia menu', () => {
       await menuFrame.click('input#insert');
       await page.waitForSelector('div[id="mceu_39"]', { hidden: true });
       const htmlData = await page.evaluate(`getData()`);
-      expect(htmlData).toBe('<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=commentary&amp;fw_type_other=&amp;covered=1&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵[<span class=\"commentary\" wce=\"__t=paratext&amp;__n=&amp;fw_type=commentary&amp;covered=1\">comm</span>]<span class=\"format_end mceNonEditable\">›</span></span>');
+      expect(htmlData).toBe('<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=commentary&amp;fw_type_other=&amp;covered=1&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;reference=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵[<span class=\"commentary\" wce=\"__t=paratext&amp;__n=&amp;fw_type=commentary&amp;covered=1\">comm</span>]<span class=\"format_end mceNonEditable\">›</span></span>');
       const xmlData = await page.evaluate(`getTEI()`);
       expect(xmlData).toBe(xmlHead + '<lb/><note type=\"commentary\">One line of untranscribed commentary text</note>' + xmlTail);
 
@@ -91,11 +91,22 @@ describe('test a optional defaults for marginalia menu', () => {
       const menuFrameHandle2 = await menuFrame.$('iframe[id="marginals_text_ifr"]');
       const menuFrame2 = await menuFrameHandle2.contentFrame();
       await menuFrame2.type('body#tinymce', '10');
+      // I can't get this to wait until the unless I specifically tell it to - I don't know why
+      await page.waitForTimeout(1000);
+
+      // as 10 is not a roman numeral the number field is not complete
+      // NB we may want to change this since it is a number!
+      // then the number field should be emptied and undisabled and the automatic checkbox unchecked
+      expect(await menuFrame.$eval('#number', el => el.disabled)).toBe(false);
+      expect(await menuFrame.$eval('#number', el => el.value)).toBe('');
+      expect(await menuFrame.$eval('#edit_number', el => el.checked)).toBe(false);
+      // check the reference field is still disabled
+      expect(await menuFrame.$eval('#reference', el => el.disabled)).toBe(true);
 
       await menuFrame.click('input#insert');
       await page.waitForSelector('div[id="mceu_39"]', { hidden: true });
       const htmlData = await page.evaluate(`getData()`);
-      expect(htmlData).toBe('<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=chapNum&amp;fw_type_other=&amp;covered=0&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=10&amp;number=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span>fw<span class=\"format_end mceNonEditable\">›</span></span>');
+      expect(htmlData).toBe('<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=chapNum&amp;fw_type_other=&amp;covered=0&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=10&amp;number=&amp;reference=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span>fw<span class=\"format_end mceNonEditable\">›</span></span>');
       const xmlData = await page.evaluate(`getTEI()`);
       expect(xmlData).toBe(xmlHead + '<num type="chapNum">10</num>' + xmlTail);
 
@@ -158,7 +169,7 @@ describe('testing with showMultilineNotesAsSingleEntry client setting as true', 
       await menuFrame.click('input#insert');
   
       const htmlData = await page.evaluate(`getData()`);
-      expect(htmlData).toBe('some commentary<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=commentary&amp;fw_type_other=&amp;covered=1&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵[<span class=\"commentary\" wce=\"__t=paratext&amp;__n=&amp;fw_type=commentary&amp;covered=1\">comm</span>]<span class=\"format_end mceNonEditable\">›</span></span>​<span class="brea" wce=\"__t=brea&amp;__n=&amp;hasBreak=no&amp;break_type=lb&amp;number=&amp;rv=&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵<span class=\"format_end mceNonEditable\">›</span></span> in here');
+      expect(htmlData).toBe('some commentary<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=commentary&amp;fw_type_other=&amp;covered=1&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;reference=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵[<span class=\"commentary\" wce=\"__t=paratext&amp;__n=&amp;fw_type=commentary&amp;covered=1\">comm</span>]<span class=\"format_end mceNonEditable\">›</span></span>​<span class="brea" wce=\"__t=brea&amp;__n=&amp;hasBreak=no&amp;break_type=lb&amp;number=&amp;rv=&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵<span class=\"format_end mceNonEditable\">›</span></span> in here');
       const xmlData = await page.evaluate(`getTEI()`);
       expect(xmlData).toBe(xmlHead + '<w>some</w><w>commentary</w><lb/><note type="commentary">One line of untranscribed commentary text</note>' +
                           '<lb n="PCL-"/><w>in</w><w>here</w>' + xmlTail);
@@ -225,7 +236,7 @@ describe('testing with showMultilineNotesAsSingleEntry client setting as true', 
       await menuFrame.click('input#insert');
   
       const htmlData = await page.evaluate(`getData()`);
-      expect(htmlData).toBe('some commentary<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=commentary&amp;fw_type_other=&amp;covered=3&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵[<span class=\"commentary\" wce=\"__t=paratext&amp;__n=&amp;fw_type=commentary&amp;covered=3\">comm</span>]<span class=\"format_end mceNonEditable\">›</span></span>​<span class="brea" wce=\"__t=brea&amp;__n=&amp;hasBreak=no&amp;break_type=lb&amp;number=&amp;rv=&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵<span class=\"format_end mceNonEditable\">›</span></span> in here');
+      expect(htmlData).toBe('some commentary<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=commentary&amp;fw_type_other=&amp;covered=3&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;reference=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵[<span class=\"commentary\" wce=\"__t=paratext&amp;__n=&amp;fw_type=commentary&amp;covered=3\">comm</span>]<span class=\"format_end mceNonEditable\">›</span></span>​<span class="brea" wce=\"__t=brea&amp;__n=&amp;hasBreak=no&amp;break_type=lb&amp;number=&amp;rv=&amp;fibre_type=&amp;page_number=&amp;running_title=&amp;facs=&amp;lb_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵<span class=\"format_end mceNonEditable\">›</span></span> in here');
       const xmlData = await page.evaluate(`getTEI()`);
       expect(xmlData).toBe(xmlHead + '<w>some</w><w>commentary</w><lb/><note type="commentary">One line of untranscribed commentary text</note><lb/><note type="commentary">One line of untranscribed commentary text</note><lb/><note type="commentary">One line of untranscribed commentary text</note>' +
                           '<lb n="PCL-"/><w>in</w><w>here</w>' + xmlTail);
@@ -286,7 +297,7 @@ describe('testing with showMultilineNotesAsSingleEntry client setting as true', 
       await menuFrame.click('input#insert');
   
       const htmlData = await page.evaluate(`getData()`);
-      expect(htmlData).toBe('in line commentary<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=commentary&amp;fw_type_other=&amp;covered=0&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span>[<span class=\"commentary\" wce=\"__t=paratext&amp;__n=&amp;fw_type=commentary&amp;covered=0\">comm</span>]<span class=\"format_end mceNonEditable\">›</span></span>');
+      expect(htmlData).toBe('in line commentary<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=commentary&amp;fw_type_other=&amp;covered=0&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;reference=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span>[<span class=\"commentary\" wce=\"__t=paratext&amp;__n=&amp;fw_type=commentary&amp;covered=0\">comm</span>]<span class=\"format_end mceNonEditable\">›</span></span>');
       const xmlData = await page.evaluate(`getTEI()`);
       expect(xmlData).toBe(xmlHead + '<w>in</w><w>line</w><w>commentary</w><note type="commentary">Untranscribed commentary text within the line</note>' + xmlTail);
     
@@ -343,7 +354,7 @@ describe('testing with showMultilineNotesAsSingleEntry client setting as true', 
       await menuFrame.click('input#insert');
   
       const htmlData = await page.evaluate(`getData()`);
-      expect(htmlData).toBe('in line lectionary<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=lectionary-other&amp;fw_type_other=&amp;covered=0&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span>[<span class=\"lectionary-other\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=0\">lect</span>]<span class=\"format_end mceNonEditable\">›</span></span>');
+      expect(htmlData).toBe('in line lectionary<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=lectionary-other&amp;fw_type_other=&amp;covered=0&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;reference=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span>[<span class=\"lectionary-other\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=0\">lect</span>]<span class=\"format_end mceNonEditable\">›</span></span>');
       const xmlData = await page.evaluate(`getTEI()`);
       expect(xmlData).toBe(xmlHead + '<w>in</w><w>line</w><w>lectionary</w><note type="lectionary-other">Untranscribed lectionary text within the line</note>' + xmlTail);
     }, 200000);
@@ -367,7 +378,7 @@ describe('testing with showMultilineNotesAsSingleEntry client setting as true', 
       await menuFrame.click('input#insert');
   
       const htmlData = await page.evaluate(`getData()`);
-      expect(htmlData).toBe('lection text next<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=lectionary-other&amp;fw_type_other=&amp;covered=2&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵[<span class=\"lectionary-other\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=2\">lect</span>]<span class=\"format_end mceNonEditable\">›</span></span>');
+      expect(htmlData).toBe('lection text next<span class=\"paratext\" wce_orig=\"\" wce=\"__t=paratext&amp;__n=&amp;help=Help&amp;fw_type=lectionary-other&amp;fw_type_other=&amp;covered=2&amp;mceu_5-open=&amp;mceu_6-open=&amp;mceu_7-open=&amp;mceu_8-open=&amp;mceu_9-open=&amp;mceu_10-open=&amp;marginals_text=&amp;number=&amp;edit_number=on&amp;reference=&amp;paratext_position=&amp;paratext_position_other=&amp;paratext_alignment=\"><span class=\"format_start mceNonEditable\">‹</span><br />↵[<span class=\"lectionary-other\" wce=\"__t=paratext&amp;__n=&amp;fw_type=lectionary-other&amp;covered=2\">lect</span>]<span class=\"format_end mceNonEditable\">›</span></span>');
       const xmlData = await page.evaluate(`getTEI()`);
       expect(xmlData).toBe(xmlHead + '<w>lection</w><w>text</w><w>next</w><lb/>' +
                           '<note type="lectionary-other">One line of untranscribed lectionary text</note><lb/>' +

--- a/__tests__/wce_tei.dom.test.js
+++ b/__tests__/wce_tei.dom.test.js
@@ -595,6 +595,32 @@ const fw = new Map([
       '<span class="format_start mceNonEditable">‹</span>fw<span class="format_end mceNonEditable">›</span></span>'
     ]
   ],
+  // quire sig with supplied number as n attribute (to check we don't break that while adding reference for titles)
+  [ 'quire sig (fw) with n attribute',
+    [ '<fw type="quireSig" n="4"><w>test</w></fw>',
+      '<span class="paratext" wce="__t=paratext&amp;__n=&amp;marginals_text=test%20&amp;' +
+      'fw_type=quireSig&amp;number=4&amp;paratext_position=&amp;paratext_position_other=">' +
+      '<span class="format_start mceNonEditable">‹</span>fw<span class="format_end mceNonEditable">›</span></span>'
+    ]
+  ],
+  // chapter title with n attribute
+  [ 'chapter title (fw) with n attribute',
+    [ '<fw type="chapTitle" n="John.1.1"><w>test</w></fw>',
+      '<span class="paratext" wce="__t=paratext&amp;__n=&amp;marginals_text=test%20&amp;' +
+      'fw_type=chapTitle&amp;reference=John.1.1&amp;paratext_position=&amp;paratext_position_other=">' +
+      '<span class="format_start mceNonEditable">‹</span>fw<span class="format_end mceNonEditable">›</span></span>'
+    ]
+  ],
+  // chapter title without n attribute
+  [ 'chapter title (fw) without n attribute',
+    [ '<fw type="chapTitle"><w>test</w></fw>',
+      '<span class="paratext" wce="__t=paratext&amp;__n=&amp;marginals_text=test%20&amp;' +
+      'fw_type=chapTitle&amp;paratext_position=&amp;paratext_position_other=">' +
+      '<span class="format_start mceNonEditable">‹</span>fw<span class="format_end mceNonEditable">›</span></span>'
+    ]
+  ],
+  // lectionary title with n attribute
+
   // chapter number in the margin
   [ 'chapter number in left margin',
     [ '<w>this</w><w>is</w><w>a</w><w>chapter</w><w>number</w><w>in</w><w>the</w><w>margin</w>' +

--- a/wce-ote/plugin/langs/de.js
+++ b/wce-ote/plugin/langs/de.js
@@ -85,6 +85,7 @@ tinymce.addI18n('de',{
 	covered : "Anzahl der überdeckten Zeilen",
 	number_attribute : 'Zahl (wie für das XML-Attribut "n" benutzt)',
 	number_calculate : "Automatische Umwandlung der Zahl",
+	reference_attribute : 'Reference (wie für das XML-Attribut "n" benutzt)',
 	numeral : "Zugehörige Zahl",
 	fw_commentary_text : "Kommentartext",
 	fw_ews : "Ews",

--- a/wce-ote/plugin/langs/en.js
+++ b/wce-ote/plugin/langs/en.js
@@ -86,6 +86,7 @@ tinymce.addI18n('en',{
 	text : "Text or number (as written on page)",
 	number_attribute : 'Number (as used for XML attribute "n")',
 	number_calculate : "Calculate number automatically",
+	reference_attribute : 'Reference (as used for XML attribute "n")',
 	numeral : "Corresponding number",
 	fw_commentary_text : "Commentary text",
 	fw_ews : "Ews",

--- a/wce-ote/plugin/paratext.htm
+++ b/wce-ote/plugin/paratext.htm
@@ -100,6 +100,11 @@
 					<td><input id="edit_number" name="edit_number" type="checkbox" onchange="checkstatus_number()" checked="checked">{#number_calculate}</input></td>
 				</tr>
 				<tr>
+					<td><label id="reference_label" for="reference">{#reference_attribute}</label></td>
+					<td colspan="3"><input id="reference" name="reference" type="text" value=""
+						size="50" maxlength="" class="reference min1 mceFocus" /></td>
+				</tr>
+				<tr>
 					<td><label id="paratext_position_label"
 						for="paratext_position">{#position}</label>
 					</td>
@@ -277,6 +282,9 @@
 			document.getElementById('number').style.backgroundColor = "#CCCCCC";
 			document.paratextinfo.edit_number.checked = "checked";
 			document.getElementById('edit_number').disabled = true;
+			document.paratextinfo.reference.value = '';
+			document.paratextinfo.reference.disabled = true;
+			document.getElementById('reference').style.backgroundColor = "#CCCCCC";
 			document.paratextinfo.covered.disabled = false;
 			document.getElementById('covered').style.backgroundColor = "white";
 			$('#marginals_text').attr('disabled', true);
@@ -289,6 +297,9 @@
 			document.getElementById('number').style.backgroundColor = "#CCCCCC";
 			document.paratextinfo.edit_number.checked = "checked";
 			document.getElementById('edit_number').disabled = true;
+			document.paratextinfo.reference.value = '';
+			document.paratextinfo.reference.disabled = true;
+			document.getElementById('reference').style.backgroundColor = "#CCCCCC";
 			document.paratextinfo.covered.disabled = true;
 			document.getElementById('covered').style.backgroundColor = "#CCCCCC";
 			$('#marginals_text').attr('disabled', true);
@@ -301,13 +312,16 @@
 			document.getElementById('number').style.backgroundColor = "#CCCCCC";
 			document.paratextinfo.edit_number.checked = "checked";
 			document.getElementById('edit_number').disabled = true;
+			document.paratextinfo.reference.value = '';
+			document.paratextinfo.reference.disabled = true;
+			document.getElementById('reference').style.backgroundColor = "#CCCCCC";
 			document.paratextinfo.covered.disabled = true;
 			document.getElementById('covered').style.backgroundColor = "#CCCCCC";
 			$('#marginals_text').attr('disabled', false);
 			marginals_text_editor.show();
 			document.paratextinfo.paratext_position.disabled = false;
 			document.paratextinfo.paratext_alignment.disabled = true;
-		} else if (v == 'runTitle' || v == 'chapTitle' || v == 'lectTitle' || v == 'lectBibRef' || v == 'lectInstruct'
+		} else if (v == 'runTitle' || v == 'lectBibRef' || v == 'lectInstruct'
 			|| v == 'colophon' || v == 'euthaliana' || v == 'gloss' || v == 'pageNum' || v == 'orn' || v == 'other') {
 			//don't get a number, only text
 			document.paratextinfo.number.value = '';
@@ -315,6 +329,24 @@
 			document.getElementById('number').style.backgroundColor = "#CCCCCC";
 			document.paratextinfo.edit_number.checked = "checked";
 			document.getElementById('edit_number').disabled = true;
+			document.paratextinfo.reference.value = '';
+			document.paratextinfo.reference.disabled = true;
+			document.getElementById('reference').style.backgroundColor = "#CCCCCC";
+			document.paratextinfo.covered.disabled = true;
+			document.getElementById('covered').style.backgroundColor = "#CCCCCC";
+			$('#marginals_text').attr('disabled', false);
+			marginals_text_editor.show();
+			document.paratextinfo.paratext_position.disabled = false;
+			document.paratextinfo.paratext_alignment.disabled = false;
+		} else if (v == 'chapTitle' || v == 'lectTitle' ) {
+			//don't get a number, only text but enable the reference field
+			document.paratextinfo.number.value = '';
+			document.paratextinfo.number.disabled = true;
+			document.getElementById('number').style.backgroundColor = "#CCCCCC";
+			document.paratextinfo.edit_number.checked = "checked";
+			document.getElementById('edit_number').disabled = true;
+			document.paratextinfo.reference.disabled = false;
+			document.getElementById('reference').style.backgroundColor = "white";
 			document.paratextinfo.covered.disabled = true;
 			document.getElementById('covered').style.backgroundColor = "#CCCCCC";
 			$('#marginals_text').attr('disabled', false);
@@ -322,8 +354,13 @@
 			document.paratextinfo.paratext_position.disabled = false;
 			document.paratextinfo.paratext_alignment.disabled = false;
 		} else {
+			document.paratextinfo.reference.value = '';
+			document.paratextinfo.reference.disabled = true;
 			document.getElementById('edit_number').disabled = false;
 			checkstatus_number();
+			document.paratextinfo.reference.value = '';
+			document.paratextinfo.reference.disabled = true;
+			document.getElementById('reference').style.backgroundColor = "#CCCCCC";
 			document.paratextinfo.covered.disabled = true;
 			document.getElementById('covered').style.backgroundColor = "#CCCCCC";
 			$('#marginals_text').attr('disabled', false);

--- a/wce-ote/plugin/paratext.htm
+++ b/wce-ote/plugin/paratext.htm
@@ -200,7 +200,9 @@
 			setup : function(ed) {
 				ed.on('change', function() {
 					marginals_text_editor.save();
-					checkstatus_number();
+					if (['chapNum', 'quireSig', 'AmmSec', 'EusCan', 'stichoi', 'andrew'].indexOf(document.paratextinfo.fw_type) !== -1) {
+						checkstatus_number();
+					}
 				});
 				ed.on('keydown',function(ed) {
 					var v = $('#fw_type').val();
@@ -216,7 +218,8 @@
 					timeout = setTimeout(function() {
 						timeout = null;
 						marginals_text_editor.save();
-						checkstatus_number(); }, 1000);
+						checkstatus_number(); 
+					}, 1000);
 				});
 			}
 		}, tinymce.EditorManager);
@@ -354,6 +357,8 @@
 			document.paratextinfo.paratext_position.disabled = false;
 			document.paratextinfo.paratext_alignment.disabled = false;
 		} else {
+			// the ones that remain are the ones we use numbers in the n attribute for (if supplied):
+			// 'chapNum', 'quireSig', 'AmmSec', 'EusCan', 'stichoi', 'andrew'
 			document.paratextinfo.reference.value = '';
 			document.paratextinfo.reference.disabled = true;
 			document.getElementById('edit_number').disabled = false;
@@ -686,9 +691,12 @@
 	function setstatus_paratext() {
 		checkstatus_position();
 		checkstatus_typ();
-		var oldnumber = document.paratextinfo.number.value; // save number
-		setnumber();
-		document.paratextinfo.number.value = oldnumber; // set former number for editing
+		// only set the number from the inner editor if we have selected one of the number types
+		if (['chapNum', 'quireSig', 'AmmSec', 'EusCan', 'stichoi', 'andrew'].indexOf(document.paratextinfo.fw_type) !== -1) {
+			var oldnumber = document.paratextinfo.number.value; // save number
+			setnumber();
+			document.paratextinfo.number.value = oldnumber; // set former number for editing
+		}
 	}
 
 	if (!tinyMCE.isIE) {

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -1433,15 +1433,28 @@ function getHtmlByTei(inputString, clientOptions) {
 			wceAttr += getWceAttributeByTei($teiNode, mapping) + '&fw_type=isolated&fw_type_other=';
 			var $next = $teiNode;
 		} else {
-			var mapping = {
-				'n' : '&number=',
-				'rend' : '&paratext_alignment=',
-				'type' : {
-					'0' : '@commentary@ews@runTitle@chapNum@chapTitle@lectTitle@lectBibRef@lectInstruct@lectionary-other@colophon@quireSig@AmmSec@EusCan@euthaliana@gloss@stichoi@pageNum@andrew@orn',
-					'1' : '&fw_type=',
-					'2' : '&fw_type=other&fw_type_other='
-				}
-			};
+			// check if this is a type that uses reference for the n attribute (if not go with number)
+			if ($teiNode.getAttribute('type') == 'chapTitle' || $teiNode.getAttribute('type') == 'lectTitle') {
+				var mapping = {
+					'n' : '&reference=',
+					'rend' : '&paratext_alignment=',
+					'type' : {
+						'0' : '@chapTitle@lectTitle',
+						'1' : '&fw_type=',
+						'2' : '&fw_type=other&fw_type_other='
+					}
+				};
+			} else {
+				var mapping = {
+					'n' : '&number=',
+					'rend' : '&paratext_alignment=',
+					'type' : {
+						'0' : '@commentary@ews@runTitle@chapNum@lectBibRef@lectInstruct@lectionary-other@colophon@quireSig@AmmSec@EusCan@euthaliana@gloss@stichoi@pageNum@andrew@orn',
+						'1' : '&fw_type=',
+						'2' : '&fw_type=other&fw_type_other='
+					}
+				};
+			}
 
 			wceAttr += getWceAttributeByTei($teiNode, mapping);
 
@@ -3489,6 +3502,11 @@ function getTeiByHtml(inputString, clientOptions) {
 		var numberValue = arr['number'];
 		if (numberValue && (fwType == 'chapNum' || fwType == 'quireSig' || fwType == 'AmmSec' || fwType == 'EusCan' || fwType == 'stichoi' || fwType == 'andrew')) {
 			$paratext.setAttribute('n', numberValue);
+		}
+		// write n attribute using reference field for certain values
+		var referenceValue = arr['reference'];
+		if (referenceValue && (fwType == 'chapTitle' || fwType == 'lectTitle')) {
+			$paratext.setAttribute('n', referenceValue);
 		}
 
 		// place


### PR DESCRIPTION
This is an addition to the schema which was made in 1.6. It adds an optional reference field (stored in the n attribute) for these particular types of marginalia (chapTitle and lectTitle) which is designed to enable them to be collated should that be required. While I was working on that I found a bug in the JavaScript for the marginalia form which I did not introduce, it has always been there. It was automatically trying to calculate the number value even for marginalia types that were not number types. This resulted in the wrong boxes being un-disabled. I fixed that as part of this and added tests for that and the new reference field.