### PR TITLE
Reverted a change from 18-Mar-2023 which removed mceNonEditable from break

### DIFF
--- a/wce-ote/plugin/plugin.js
+++ b/wce-ote/plugin/plugin.js
@@ -592,7 +592,7 @@
 			if (lbpos === undefined || lbpos === null)
 				lbpos = WCEUtils.modifyBreakPosition(ed);
 
-			var wceClass = 'class="brea"', wceAttr;
+			var wceClass = 'class="mceNonEditable brea"', wceAttr;
 
 			//how many member does a group have
 			var groupCount;

--- a/wce-ote/wce_tei.js
+++ b/wce-ote/wce_tei.js
@@ -1233,7 +1233,7 @@ function getHtmlByTei(inputString, clientOptions) {
 			return null;
 		}
 
-		$newNode.setAttribute('class', 'brea');
+		$newNode.setAttribute('class', 'mceNonEditable brea');
 		var _id = $teiNode.getAttribute('id');
 		if (_id) {
 			$newNode.setAttribute('id', _id);


### PR DESCRIPTION
@catsmith, mceNonEditable was removed from break elements with this commit:

https://github.com/scribe777/wfce-ote/commit/20186b2c050cb3b0de067c3d7fa9df8e0cee2aa6

This allows a user to place their cursor in the middle of a break, e.g., ‹PB 1r› and hit [enter] which will add the linebreak within the span of the PB display.

I am sure you had a reason for removing the mceNonEditable flag from break, but this is causing problems for our editors now so I have reverted it here.  I will leave this PR open and unmerged until we discuss, in case you have a better solution.