### PR TITLE
fixed handling of ',' to allow arabic input method to function

### DIFF
--- a/__tests__/default_functional_tests/basic_functions.tests.js
+++ b/__tests__/default_functional_tests/basic_functions.tests.js
@@ -341,9 +341,6 @@ describe('testing basic word/pc level functions', () => {
         const xmlData = await page.evaluate(`getTEI()`);
         expect(xmlData).toBe(xmlHead + '<w>space</w><w>between</w><space unit="millimetres" extent="4"/><w>words</w>' + xmlTail);
 
-
-
-
     }, 200000);
 
     // pc typed in
@@ -363,7 +360,7 @@ describe('testing basic word/pc level functions', () => {
         const htmlData = await page.evaluate(`getData()`);
         expect(htmlData).toBe('my words<span class="pc" wce_orig="" wce="__t=pc">' +
             '<span class="format_start mceNonEditable">‹</span>,' +
-            '<span class="format_end mceNonEditable">›</span></span>  with comma');
+            '<span class="format_end mceNonEditable">›</span></span>  with comma');
         const xmlData = await page.evaluate(`getTEI()`);
         expect(xmlData).toBe(xmlHead + '<w>my</w><w>words</w><pc>,</pc><w>with</w><w>comma</w>' + xmlTail);
     }, 200000);

--- a/__tests__/default_functional_tests/basic_functions.tests.js
+++ b/__tests__/default_functional_tests/basic_functions.tests.js
@@ -357,6 +357,17 @@ describe('testing basic word/pc level functions', () => {
         expect(xmlData).toBe(xmlHead + '<w>my</w><w>words</w><pc>.</pc>' + xmlTail);
     }, 200000);
 
+    // pc typed in
+    test('test typed comma because we changed the way the key is identified', async () => {
+        await frame.type('body#tinymce', 'my words, with comma');
+        const htmlData = await page.evaluate(`getData()`);
+        expect(htmlData).toBe('my words<span class="pc" wce_orig="" wce="__t=pc">' +
+            '<span class="format_start mceNonEditable">‹</span>,' +
+            '<span class="format_end mceNonEditable">›</span></span>  with comma');
+        const xmlData = await page.evaluate(`getTEI()`);
+        expect(xmlData).toBe(xmlHead + '<w>my</w><w>words</w><pc>,</pc><w>with</w><w>comma</w>' + xmlTail);
+    }, 200000);
+
     // pc with menu
     test('test pc with menu', async () => {
         await frame.type('body#tinymce', 'my words');

--- a/wce-ote/plugin/plugin.js
+++ b/wce-ote/plugin/plugin.js
@@ -2605,7 +2605,7 @@
 				// :
 				tinyMCE.activeEditor.execCommand('mceAdd_pc', ':');
 				stopEvent(ed, e);
-			} else if (ek == 188 && !e.shiftKey) {
+			} else if (e.key && e.key == ',') {
 				// ,
 				tinyMCE.activeEditor.execCommand('mceAdd_pc', ',');
 				stopEvent(ed, e);


### PR DESCRIPTION
The WCE keyboard handling is kindof messed up.  All kinds of detection for keyboard type and key number.  It should be changed to handle the input received from the OS input-method.  It should not try to detect language and keyboard type and handle all this to intercept the correct key.  This change specifically allow arabic input method to function, which uses the key with a ',' on most keyboards for an arabic accent.  This change just checks if we got a ',' from the input-method and if so then treat it as punctuation.