### PR TITLE
add --no-sandbox option in functional tests

### DIFF
--- a/__tests__/default_functional_tests/add_structure_menu.tests.js
+++ b/__tests__/default_functional_tests/add_structure_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/appearance.tests.js
+++ b/__tests__/default_functional_tests/appearance.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/basic_functions.tests.js
+++ b/__tests__/default_functional_tests/basic_functions.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
         // for online testing (only ever commit these)
         headless: "new",
         slowMo: 60,
-        args: ['--disable-web-security']
+        args: ['--disable-web-security', '--no-sandbox']
     });
 });
 

--- a/__tests__/default_functional_tests/break_menu.tests.js
+++ b/__tests__/default_functional_tests/break_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/correction_menu.tests.js
+++ b/__tests__/default_functional_tests/correction_menu.tests.js
@@ -26,7 +26,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/delete_structure_menu.tests.js
+++ b/__tests__/default_functional_tests/delete_structure_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/gap_menu.tests.js
+++ b/__tests__/default_functional_tests/gap_menu.tests.js
@@ -26,7 +26,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/marginalia_menu.tests.js
+++ b/__tests__/default_functional_tests/marginalia_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/note_menu.tests.js
+++ b/__tests__/default_functional_tests/note_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/ornamentation_menu.tests.js
+++ b/__tests__/default_functional_tests/ornamentation_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/default_functional_tests/unclear_menu.tests.js
+++ b/__tests__/default_functional_tests/unclear_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/nondefault_functional_tests/add_structure_nd_menu.tests.js
+++ b/__tests__/nondefault_functional_tests/add_structure_nd_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/nondefault_functional_tests/appearance_nd.tests.js
+++ b/__tests__/nondefault_functional_tests/appearance_nd.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
         // for online testing (only ever commit these)
         headless: "new",
         slowMo: 60,
-        args: ['--disable-web-security']
+        args: ['--disable-web-security', '--no-sandbox']
     });
 });
 

--- a/__tests__/nondefault_functional_tests/basic_functions_nd.tests.js
+++ b/__tests__/nondefault_functional_tests/basic_functions_nd.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
         // for online testing (only ever commit these)
         headless: "new",
         slowMo: 60,
-        args: ['--disable-web-security']
+        args: ['--disable-web-security', '--no-sandbox']
     });
 });
 

--- a/__tests__/nondefault_functional_tests/basic_settings_nd.tests.js
+++ b/__tests__/nondefault_functional_tests/basic_settings_nd.tests.js
@@ -34,7 +34,7 @@ beforeAll(async () => {
         // for online testing (only ever commit these)
         headless: "new",
         slowMo: 80,
-        args: ['--disable-web-security']
+        args: ['--disable-web-security', '--no-sandbox']
     });
 });
 

--- a/__tests__/nondefault_functional_tests/delete_structure_nd_menu.tests.js
+++ b/__tests__/nondefault_functional_tests/delete_structure_nd_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/nondefault_functional_tests/gap_nd_menu.tests.js
+++ b/__tests__/nondefault_functional_tests/gap_nd_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/nondefault_functional_tests/marginalia_nd_menu.tests.js
+++ b/__tests__/nondefault_functional_tests/marginalia_nd_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 80,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
       });
 });
 

--- a/__tests__/nondefault_functional_tests/ornamentation_nd_menu.tests.js
+++ b/__tests__/nondefault_functional_tests/ornamentation_nd_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 

--- a/__tests__/nondefault_functional_tests/space_nd_menu.tests.js
+++ b/__tests__/nondefault_functional_tests/space_nd_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
         // for online testing (only ever commit these)
         headless: "new",
         slowMo: 60,
-        args: ['--disable-web-security']
+        args: ['--disable-web-security', '--no-sandbox']
     });
 });
 

--- a/__tests__/nondefault_functional_tests/unclear_nd_menu.tests.js
+++ b/__tests__/nondefault_functional_tests/unclear_nd_menu.tests.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
     // for online testing (only ever commit these)
     headless: "new",
     slowMo: 60,
-    args: ['--disable-web-security']
+    args: ['--disable-web-security', '--no-sandbox']
   });
 });
 


### PR DESCRIPTION
Something must have changed in one of the :latest packages we use that broke all the browser tests. Probably an OS update. This fixes it and is okay to do in a CI pipeline.